### PR TITLE
[feat] 채팅 메시지 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//web-socket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/halfgallon/withcon/domain/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.halfgallon.withcon.domain.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    //클라이언트에게 메시지 전달
+    registry.enableSimpleBroker("/topic");
+    //클라이언트의 Send 요청 처리
+    registry.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws")
+        .addInterceptors()
+        .setAllowedOriginPatterns("*");
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/constant/MessageType.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/constant/MessageType.java
@@ -1,0 +1,15 @@
+package com.halfgallon.withcon.domain.chat.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MessageType {
+  ENTER("입장"),
+  CHAT("채팅"),
+  EXIT("퇴장"),
+  KICK("강퇴");
+
+  private final String description;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,55 @@
+package com.halfgallon.withcon.domain.chat.controller;
+
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageRequest;
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageResponse;
+import com.halfgallon.withcon.domain.chat.service.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+  private final SimpMessageSendingOperations sendingOperations;
+  private final ChatMessageService chatMessageService;
+
+  @MessageMapping("/chat/message/{roomId}")
+  public void sendMessage(@Payload ChatMessageRequest chat,
+                          @DestinationVariable("roomId") Long roomId) {
+
+    ChatMessageResponse response = chatMessageService.chatMessage(chat, roomId);
+
+    sendingOperations.convertAndSend("/topic/chatRoom/" + roomId, response.getMessage());
+    log.info("Message [{}] send by member: {} to chatting room: {}",
+        chat.getMessage(), chat.getMemberId(), roomId);
+  }
+
+  @MessageMapping("/chat/enter/{roomId}")
+  public void enterMember(@Payload ChatMessageRequest chat,
+                          @DestinationVariable("roomId") Long roomId) {
+
+    ChatMessageResponse response = chatMessageService.enterMessage(chat, roomId);
+
+    sendingOperations.convertAndSend("/topic/chatRoom/" + roomId, response.getMessage());
+    log.info("Message [{}] send by member: {} to chatting room: {}",
+        response.getMessage(), chat.getMemberId(), roomId);
+  }
+
+  @MessageMapping("/chat/exit/{roomId}")
+  public void exitMember(@Payload ChatMessageRequest chat,
+                          @DestinationVariable("roomId") Long roomId) {
+
+    ChatMessageResponse response = chatMessageService.exitMessage(chat, roomId);
+
+    sendingOperations.convertAndSend("/topic/chatRoom/" + roomId, response.getMessage());
+    log.info("Message [{}] send by member: {} to chatting room: {}",
+        response.getMessage(), chat.getMemberId(), roomId);
+  }
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageRequest.java
@@ -1,0 +1,14 @@
+package com.halfgallon.withcon.domain.chat.dto;
+
+import com.halfgallon.withcon.domain.chat.constant.MessageType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageRequest {
+  private Long memberId;
+  private String message;
+  private MessageType messageType;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,22 @@
+package com.halfgallon.withcon.domain.chat.dto;
+
+import com.halfgallon.withcon.domain.chat.constant.MessageType;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageResponse {
+
+  private Long memberId;
+  private Long chatRoomId;
+
+  private String message;
+  private MessageType messageType;
+
+  private LocalDateTime time;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,42 @@
+package com.halfgallon.withcon.domain.chat.entity;
+
+import com.halfgallon.withcon.domain.chat.constant.MessageType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "room_id")
+  private ChatRoom room;
+
+  @Column(columnDefinition = "TEXT")
+  private String message;
+
+  @Enumerated(value = EnumType.STRING)
+  private MessageType chattingType;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime sendAt;
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,22 @@
+package com.halfgallon.withcon.domain.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String name;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package com.halfgallon.withcon.domain.chat.repository;
+
+import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,11 @@
+package com.halfgallon.withcon.domain.chat.service;
+
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageRequest;
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageResponse;
+
+public interface ChatMessageService {
+  ChatMessageResponse chatMessage(ChatMessageRequest request, Long roomId);
+  ChatMessageResponse enterMessage(ChatMessageRequest request, Long roomId);
+  ChatMessageResponse exitMessage(ChatMessageRequest request, Long roomId);
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatMessageServiceImpl.java
@@ -1,0 +1,52 @@
+package com.halfgallon.withcon.domain.chat.service;
+
+import com.halfgallon.withcon.domain.chat.constant.MessageType;
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageRequest;
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageResponse;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageServiceImpl implements ChatMessageService {
+
+  @Override
+  public ChatMessageResponse chatMessage(ChatMessageRequest request, Long roomId) {
+    return ChatMessageResponse.builder()
+        .chatRoomId(roomId)
+        .memberId(request.getMemberId())
+        .message(request.getMessage())
+        .messageType(MessageType.CHAT)
+        .time(LocalDateTime.now())
+        .build();
+  }
+
+  @Override
+  public ChatMessageResponse enterMessage(ChatMessageRequest request, Long roomId) {
+
+    String message = "님이 입장하였습니다.";
+
+    return ChatMessageResponse.builder()
+        .chatRoomId(roomId)
+        .memberId(request.getMemberId())
+        .message(message)
+        .messageType(MessageType.ENTER)
+        .time(LocalDateTime.now())
+        .build();
+  }
+
+  @Override
+  public ChatMessageResponse exitMessage(ChatMessageRequest request, Long roomId) {
+    String message = "님이 퇴장하였습니다.";
+
+    return ChatMessageResponse.builder()
+        .chatRoomId(roomId)
+        .memberId(request.getMemberId())
+        .message(message)
+        .messageType(MessageType.EXIT)
+        .time(LocalDateTime.now())
+        .build();
+  }
+
+}


### PR DESCRIPTION
## 📝작업 내용

1. 채팅 메시지 송-수신 기능 설정


## 💬리뷰 참고사항
1. stomp를 이용하여 configuration 기능 구현
2. 채팅 타입을 설정하여 입장,퇴장,채팅에 관해 타입 지정
3. 채팅 메시지 송-수신을 위한 컨트롤러 및 서비스 구성
4. 관련 블로그 정리 : https://miiro-under.tistory.com/273

## #️⃣연관된 이슈

 #5 
