### PR TITLE
[feat] QueryDsl을 이용한 Exist, Pagination 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.8'
@@ -39,6 +45,12 @@ dependencies {
 
 	//web-socket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('bootBuildImage') {
@@ -47,4 +59,17 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+/**
+ * QueryDSL Build Options
+ */
+def querydslDir = 'src/main/generated'
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean {
+	delete file(querydslDir)
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatParticipantRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long>, CustomChatParticipantRepository {
 
   boolean existsByMemberId(Long MemberId);
 

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatParticipantRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatParticipantRepository.java
@@ -1,0 +1,7 @@
+package com.halfgallon.withcon.domain.chat.repository;
+
+public interface CustomChatParticipantRepository {
+
+  boolean checkRoomManager(Long memberId);
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatParticipantRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatParticipantRepository.java
@@ -1,7 +1,12 @@
 package com.halfgallon.withcon.domain.chat.repository;
 
+import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface CustomChatParticipantRepository {
 
   boolean checkRoomManager(Long memberId);
 
+  Page<ChatParticipant> findAllMyChattingRoom(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatParticipantRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatParticipantRepositoryImpl.java
@@ -1,10 +1,17 @@
 package com.halfgallon.withcon.domain.chat.repository.impl;
 
 import static com.halfgallon.withcon.domain.chat.entity.QChatParticipant.chatParticipant;
+import static com.halfgallon.withcon.domain.chat.entity.QChatRoom.chatRoom;
 
+import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
 import com.halfgallon.withcon.domain.chat.repository.CustomChatParticipantRepository;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
 public class CustomChatParticipantRepositoryImpl implements CustomChatParticipantRepository {
@@ -22,4 +29,21 @@ public class CustomChatParticipantRepositoryImpl implements CustomChatParticipan
     return fetchOne != null;
   }
 
+  @Override
+  public Page<ChatParticipant> findAllMyChattingRoom(Long memberId, Pageable pageable) {
+    List<ChatParticipant> list = jpaQueryFactory.selectFrom(chatParticipant)
+        .innerJoin(chatParticipant.chatRoom, chatRoom)
+        .fetchJoin()
+        .where(chatParticipant.member.id.eq(memberId))
+        .orderBy(chatParticipant.chatRoom.userCount.desc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Long> countQuery = jpaQueryFactory.select(chatParticipant.count())
+        .from(chatParticipant)
+        .where(chatParticipant.member.id.eq(memberId));
+
+    return PageableExecutionUtils.getPage(list, pageable, countQuery::fetchOne);
+  }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatParticipantRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatParticipantRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.halfgallon.withcon.domain.chat.repository.impl;
+
+import static com.halfgallon.withcon.domain.chat.entity.QChatParticipant.chatParticipant;
+
+import com.halfgallon.withcon.domain.chat.repository.CustomChatParticipantRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomChatParticipantRepositoryImpl implements CustomChatParticipantRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public boolean checkRoomManager(Long memberId) {
+    Integer fetchOne = jpaQueryFactory.selectOne()
+        .from(chatParticipant)
+        .where(chatParticipant.member.id.eq(memberId),
+            chatParticipant.isManager.eq(true))
+        .fetchFirst();
+
+    return fetchOne != null;
+  }
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImpl.java
@@ -25,7 +25,7 @@ public class ChatParticipantServiceImpl implements ChatParticipantService {
       throw new CustomException(USER_NOT_PARTICIPANT_CHATTING);
     }
 
-    return chatParticipantRepository.findAllByMemberId(memberId, pageable)
+    return chatParticipantRepository.findAllMyChattingRoom(memberId, pageable)
         .map(ChatParticipantResponse::fromEntity);
   }
 

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -119,7 +119,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
       throw new CustomException(DUPLICATE_CHATROOM);
     }
     //채팅방은 1인당 1개만 생성이 가능하다.
-    if (participantRepository.existRoomLeader(request.memberId())) {
+    if (participantRepository.checkRoomManager(request.memberId())) {
       throw new CustomException(USER_JUST_ONE_CREATE_CHATROOM);
     }
   }

--- a/src/main/java/com/halfgallon/withcon/global/config/QueryDslConfig.java
+++ b/src/main/java/com/halfgallon/withcon/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.halfgallon.withcon.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}


### PR DESCRIPTION
## 📝작업 내용
1. QueryDsl 설정
    - QueryDslConfig 파일 생성
    - QueryDsl 파일 속성(build.gradle) 추가
    
2. Querydsl을 이용한 페이지네이션 구성
    - JPQL `@Query` 문을 이용한 쿼리문을 `QueryDsl` 로 변경
    - `PageableExecutionUtils.getPage()` 방식을 이용하여 페이징 최적화 진행
   - `new PageImpl()`을 이용하면 무조건적으로 count 쿼리 진행
    -> 이로 인해 쿼리를 총 2번(select, count) 쿼리를 진행하게 된다.
   - `PageableExecutionUtils.getPage()`는 `totalSupplier` 라는 함수형 인터페이스를 사용하여 특정 조건 
   즉, 페이지의 콘텐츠 사이즈가 한 페이지의 사이즈보다 작을 경우 count 쿼리를 진행하지 않는다.

3. JPQL Exist -> Querydsl 변경
   - JPQL `@Query` 문을 이용한 쿼리문을 `QueryDsl` 로 변경
   - `JPA`로 구성하려고 했으나 조건에 맞는 쿼리문을 작성하려면 `memberId`, `isManager` 2개의 매개변수가 있어야 작동이 되는데 `exists` 문에 매개변수가 1개만 들어가는 것이 현재 코드 구성 상 알맞다고 판단되어 `QueryDsl`로 설정
  
## 💬리뷰 참고사항

> QueryDsl 인텔리제이 설정 프로그램 `git pull` 이후에 진행 시 세팅 방법
1. 인텔리제이에 우측 상단 `gradle` 버튼을 클릭한다.
2. `build → clean` 버튼을 눌러서 초기화를 시킨다.
3. clean 이 완료 되었다면 `other → complieJava` 를 눌러서 컴파일을 진행한다.
4. 컴파일이 완료되면 build.gradle 에서 설정한 `src/main/generated` 파일이 생성된다.

> Querydsl을 이용한 페이지네이션 구성
- 관련 내용 트러블 슈팅 : https://deciduous-milk-b6f.notion.site/QueryDsl-56322eda1396449bb263a4578f3f8424

> JPQL Exist -> Querydsl 변경
- 관련 내용 트러블 슈팅 : https://deciduous-milk-b6f.notion.site/JPQL-Exist-QueryDsl-176fa7d418d7497aa885be7fd1721306


## #️⃣연관된 이슈
(close) #17 
