### PR TITLE
[feat] 채팅 태그 기능 추가

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
@@ -1,12 +1,13 @@
 package com.halfgallon.withcon.domain.chat.dto;
 
 import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import java.util.List;
 
 public record ChatRoomRequest(
     Long memberId,
-    String name
+    String name,
+    List<String> tags
 ) {
-
   public ChatRoom toEntity() {
     return ChatRoom.builder()
         .name(this.name)

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomResponse.java
@@ -1,13 +1,16 @@
 package com.halfgallon.withcon.domain.chat.dto;
 
 import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import com.halfgallon.withcon.domain.tag.dto.TagDto;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record ChatRoomResponse(
     Long chatRoomId,
     String name,
-    Integer userCount
+    Integer userCount,
+    List<TagDto> tagList
 ) {
 
   public static ChatRoomResponse fromEntity(ChatRoom chatRoom) {
@@ -15,6 +18,7 @@ public record ChatRoomResponse(
         .chatRoomId(chatRoom.getId())
         .name(chatRoom.getName())
         .userCount(chatRoom.getUserCount())
+        .tagList(chatRoom.getTags().stream().map(TagDto::fromEntity).toList())
         .build();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.chat.entity;
 
+import com.halfgallon.withcon.domain.tag.entity.Tag;
 import com.halfgallon.withcon.global.entity.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -36,6 +37,10 @@ public class ChatRoom extends BaseTimeEntity {
   @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
   List<ChatParticipant> chatParticipants = new ArrayList<>();
 
+  @Builder.Default
+  @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+  List<Tag> tags = new ArrayList<>();
+
   public void updateUserCount() {
     this.userCount = this.chatParticipants.size();
   }
@@ -50,4 +55,7 @@ public class ChatRoom extends BaseTimeEntity {
     this.updateUserCount();
   }
 
+  public void addTag(Tag tag) {
+    this.tags.add(tag);
+  }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -18,6 +18,8 @@ import com.halfgallon.withcon.domain.chat.service.ChatRoomService;
 import com.halfgallon.withcon.domain.member.dto.MemberDto;
 import com.halfgallon.withcon.domain.member.entity.Member;
 import com.halfgallon.withcon.domain.member.repository.MemberRepository;
+import com.halfgallon.withcon.domain.tag.entity.Tag;
+import com.halfgallon.withcon.domain.tag.repository.TagRepository;
 import com.halfgallon.withcon.global.exception.CustomException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   private final ChatRoomRepository chatRoomRepository;
   private final ChatParticipantRepository participantRepository;
   private final MemberRepository memberRepository;
+  private final TagRepository tagRepository;
+
   @Override
   public ChatRoomResponse createChatRoom(ChatRoomRequest request) {
     //멤버 조회 검사(@AuthenticationPrincipal) -> 임시로 memberRepository에서 들고와서 진행
@@ -50,6 +54,20 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             .member(member)
             .isManager(true)
             .build()));
+
+    //태그가 있는 경우에만 - 해당 태그 저장
+    if (request.tags() != null) {
+      List<Tag> tagList = request.tags()
+          .stream()
+          .map(t -> Tag.builder()
+              .name(t)
+              .chatRoom(chatRoom)
+              .build())
+          .toList();
+
+      tagRepository.saveAll(tagList);
+      tagList.forEach(chatRoom::addTag);
+    }
 
     return ChatRoomResponse.fromEntity(chatRoom);
   }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
@@ -1,0 +1,27 @@
+package com.halfgallon.withcon.domain.tag.controller;
+
+import com.halfgallon.withcon.domain.tag.service.TagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tag")
+@RequiredArgsConstructor
+public class TagController {
+
+  private final TagService tagService;
+
+
+  /**
+   * 태그 정보 조회(태그 갯수 많은 순으로 정렬)
+   * @return : name(태그 이름), count(태그 생성 갯수)
+   */
+  @GetMapping
+  public ResponseEntity<?> findTagOrderByCount() {
+    return ResponseEntity.ok(tagService.findTagOrderByCount());
+  }
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
@@ -19,7 +19,7 @@ public class TagController {
    * 태그 정보 조회(태그 갯수 많은 순으로 정렬)
    * @return : name(태그 이름), count(태그 생성 갯수)
    */
-  @GetMapping
+  @GetMapping("/search")
   public ResponseEntity<?> findTagOrderByCount() {
     return ResponseEntity.ok(tagService.findTagOrderByCount());
   }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/dto/TagCountDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/dto/TagCountDto.java
@@ -1,0 +1,9 @@
+package com.halfgallon.withcon.domain.tag.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TagCountDto {
+  private String name;
+  private Long count;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/tag/dto/TagDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/dto/TagDto.java
@@ -1,0 +1,15 @@
+package com.halfgallon.withcon.domain.tag.dto;
+
+import com.halfgallon.withcon.domain.tag.entity.Tag;
+import lombok.Builder;
+
+@Builder
+public record TagDto(
+    String name
+) {
+  public static TagDto fromEntity(Tag tag) {
+    return TagDto.builder()
+        .name(tag.getName())
+        .build();
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/tag/entity/Tag.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/entity/Tag.java
@@ -1,0 +1,35 @@
+package com.halfgallon.withcon.domain.tag.entity;
+
+import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chatRoom_id")
+  private ChatRoom chatRoom;
+
+  @Column(nullable = false)
+  private String name;
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/CustomTagRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/CustomTagRepository.java
@@ -1,0 +1,10 @@
+package com.halfgallon.withcon.domain.tag.repository;
+
+import com.halfgallon.withcon.domain.tag.dto.TagCountDto;
+import java.util.List;
+
+public interface CustomTagRepository {
+
+  List<TagCountDto> findTagOrderByCount();
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package com.halfgallon.withcon.domain.tag.repository;
+
+import com.halfgallon.withcon.domain.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TagRepository extends JpaRepository<Tag, Long> {
+public interface TagRepository extends JpaRepository<Tag, Long>, CustomTagRepository {
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.halfgallon.withcon.domain.tag.repository.impl;
+
+import static com.halfgallon.withcon.domain.tag.entity.QTag.tag;
+
+import com.halfgallon.withcon.domain.tag.dto.TagCountDto;
+import com.halfgallon.withcon.domain.tag.repository.CustomTagRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomTagRepositoryImpl implements CustomTagRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<TagCountDto> findTagOrderByCount() {
+    return jpaQueryFactory.select(
+        Projections.fields(TagCountDto.class,
+            tag.name,
+            tag.count().as("count")
+        ))
+        .from(tag)
+        .orderBy(tag.count().desc())
+        .groupBy(tag.name)
+        .limit(10)  //인기 태그 Top 10
+        .fetch();
+  }
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/tag/service/TagService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/service/TagService.java
@@ -1,0 +1,9 @@
+package com.halfgallon.withcon.domain.tag.service;
+
+import com.halfgallon.withcon.domain.tag.dto.TagCountDto;
+import java.util.List;
+
+public interface TagService {
+
+  List<TagCountDto> findTagOrderByCount();
+}

--- a/src/main/java/com/halfgallon/withcon/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/service/TagServiceImpl.java
@@ -1,0 +1,22 @@
+package com.halfgallon.withcon.domain.tag.service;
+
+import com.halfgallon.withcon.domain.tag.dto.TagCountDto;
+import com.halfgallon.withcon.domain.tag.repository.TagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TagServiceImpl implements TagService {
+
+  private final TagRepository tagRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<TagCountDto> findTagOrderByCount() {
+    return tagRepository.findTagOrderByCount();
+  }
+
+}

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -3,8 +3,9 @@ POST http://localhost:8080/chatRoom
 Content-Type: application/json
 
 {
-  "memberId": 1,
-  "name": "1번채팅방"
+  "memberId": 7,
+  "name": "7번채팅방",
+  "tags": ["#3번", "#7번"]
 }
 
 ### 채팅방 조회

--- a/src/test/http/tag.http
+++ b/src/test/http/tag.http
@@ -1,0 +1,3 @@
+### 태그 정보 조회(태그 갯수 정렬)
+GET http://localhost:8080/tag
+Content-Type: application/json

--- a/src/test/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomControllerTest.java
@@ -48,7 +48,26 @@ class ChatRoomControllerTest {
   }
 
   @Test
-  @DisplayName("채팅방 생성 완료")
+  @DisplayName("채팅방 생성 완료 - 태그 추가")
+  void createChatRoom_withTag_Success() throws Exception {
+    //given
+    given(chatRoomService.createChatRoom(any()))
+        .willReturn(getChatRoomResponse());
+
+    //when
+    //then
+    ChatRoomRequest request = new ChatRoomRequest(1L, "1번 채팅방",
+        List.of("#1번방", "#2번방"));
+
+    mockMvc.perform(post("/chatRoom")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 완료 - 태그 제외")
   void createChatRoom_Success() throws Exception {
     //given
     given(chatRoomService.createChatRoom(any()))
@@ -56,9 +75,11 @@ class ChatRoomControllerTest {
 
     //when
     //then
+    ChatRoomRequest request = new ChatRoomRequest(1L, "1번 채팅방", null);
+
     mockMvc.perform(post("/chatRoom")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(new ChatRoomRequest(1L, "1번 채팅방"))))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isCreated())
         .andDo(print());
   }

--- a/src/test/java/com/halfgallon/withcon/domain/tag/repository/TagRepositoryTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/tag/repository/TagRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.halfgallon.withcon.domain.tag.repository;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.halfgallon.withcon.domain.tag.dto.TagCountDto;
+import com.halfgallon.withcon.domain.tag.entity.Tag;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+class TagRepositoryTest {
+
+  @Autowired
+  private TagRepository tagRepository;
+
+  @Test
+  @DisplayName("태그 정보 조회 - 태그 갯수 많은 순으로 정렬")
+  void findTagOrderByCount() {
+    //given
+    for (int i = 0; i < 5; i++) {
+      tagRepository.save(Tag.builder()
+          .name("#1번채팅방")
+          .build());
+    }
+
+    for (int i = 0; i < 3; i++) {
+      tagRepository.save(Tag.builder()
+          .name("#2번채팅방")
+          .build());
+    }
+
+    for (int i = 0; i < 2; i++) {
+      tagRepository.save(Tag.builder()
+          .name("#10번채팅방")
+          .build());
+    }
+
+    //when
+    List<TagCountDto> tagOrderByCount = tagRepository.findTagOrderByCount();
+
+    //then
+    assertThat(tagOrderByCount.get(0).getCount()).isEqualTo(5);
+    assertThat(tagOrderByCount.get(0).getName()).isEqualTo("#1번채팅방");
+  }
+}


### PR DESCRIPTION
## 📝작업 내용
1.  채팅 태그 기능 추가
      - 채팅 태그(tag) 객체 생성(Entity, Repository, Dto)
      - 채팅룸 <-> 태그 양방향 매핑 진행(1:N)
      - `ChatRoomRequest`, `ChatRoomResponse` 시에 `tagList` 추가
      - 채팅방 생성(`createChatRoom`) 시에 tag가 `null`이 아닌 경우 태그 정보 저장

2. 채팅 태그 조회 기능 추가
    - `TagCountDto` 생성
    - `DTO` 반환 형식의 `Querydsl` 구현
    - `tag Count` 내림차순 정렬 조회 기능 구현
    - 기존 만들었던 엔티티의 경우에는 `count`를 반환하지 않는다. 하지만 HTTP 요청 시에 필요한 내용이었기 때문에 
    `count`를 구성하는 `DTO`를 생성하여 쿼리문을 반환하도록 기능을 구현했습니다.

3. 테스트 코드 작성
   - API 테스트
      - `tags` 기능 추가 http 테스트 진행
      - 태그 `count` 내림차순하여 정보 조회
   - 테스트 코드 작성
     - 채팅방 개설 시에 `tags` 기능 추가 테스트 진행
     - `TagRepository` 테스트 진행

## 💬리뷰 참고사항
1. 해당 이슈 트러블 슈팅 : https://deciduous-milk-b6f.notion.site/Dto-Querydsl-c76a2093b858406291d199eced53261f
```java
@Override
  public List<TagCountDto> findTagOrderByCount() {
    return jpaQueryFactory.select(
        Projections.fields(TagCountDto.class,
            tag.name,
            tag.count().as("count")
        ))
        .from(tag)
        .orderBy(tag.count().desc())
        .groupBy(tag.name)
        .limit(10)  //인기 태그 Top 10
        .fetch();
  }
```
위에서 사용한 `DTO`를 반환하는 방식 중에서 `필드를 직접 접근`하는 방법을 이용한 내용입니다.

위에서 사용한 `Projections.fields` 는 필드에 값을 바로 넣어주기 때문에 

`setter`와 `기본 생성자` 필요없습니다. → Dto를 생성할 때 `@Getter` 설정만 진행합니다.

`Projections.fields` 안에 사용할 `DTO 클래스` 와 해당 DTO에 들어가는 `변수를 작성` 해주면 됩니다.

2. 태그 카운트 내림차순 정렬 조회 테스트 내용
![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/ac184989-ac7c-4fe3-bf2c-8267ddf3da68)


## #️⃣연관된 이슈
closes #31 
