### PR TITLE
[feat] 토큰 검증 및 액세스 토큰 재발급 API 추가

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/auth/constant/AuthConstant.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/constant/AuthConstant.java
@@ -1,0 +1,9 @@
+package com.halfgallon.withcon.domain.auth.constant;
+
+public class AuthConstant {
+
+  public static final String ACCESS_TOKEN_HEADER_NAME = "Authorization";
+  public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+  public static final String ACCESS_TOKEN_PREFIX = "Bearer ";
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/controller/AuthController.java
@@ -1,11 +1,17 @@
 package com.halfgallon.withcon.domain.auth.controller;
 
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.ACCESS_TOKEN_PREFIX;
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.REFRESH_TOKEN_COOKIE_NAME;
+
+import com.halfgallon.withcon.domain.auth.constant.AuthConstant;
 import com.halfgallon.withcon.domain.auth.dto.request.AuthJoinRequest;
 import com.halfgallon.withcon.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,5 +26,16 @@ public class AuthController {
   public ResponseEntity<Void> join(@RequestBody @Valid AuthJoinRequest authJoinRequest) {
     authService.join(authJoinRequest);
     return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  @PostMapping("/auth/reissue")
+  public ResponseEntity<Void> reissueAccessToken(
+      @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
+    String newAccessToken = authService.reissueAccessToken(refreshToken);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(AuthConstant.ACCESS_TOKEN_HEADER_NAME, ACCESS_TOKEN_PREFIX + newAccessToken);
+
+    return new ResponseEntity<>(headers, HttpStatus.OK);
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/auth/manager/JwtManager.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/manager/JwtManager.java
@@ -1,5 +1,9 @@
 package com.halfgallon.withcon.domain.auth.manager;
 
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.exception.ErrorCode;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/com/halfgallon/withcon/domain/auth/repository/AccessTokenRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/repository/AccessTokenRepository.java
@@ -1,10 +1,12 @@
 package com.halfgallon.withcon.domain.auth.repository;
 
 import com.halfgallon.withcon.domain.auth.entity.AccessToken;
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AccessTokenRepository extends CrudRepository<AccessToken, Long> {
 
+  Optional<AccessToken> findByAccessToken(String accessToken);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/repository/RefreshTokenRepository.java
@@ -1,10 +1,12 @@
 package com.halfgallon.withcon.domain.auth.repository;
 
 import com.halfgallon.withcon.domain.auth.entity.RefreshToken;
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
 
+  Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/config/SecurityConfig.java
@@ -1,9 +1,13 @@
 package com.halfgallon.withcon.domain.auth.security.config;
 
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halfgallon.withcon.domain.auth.constant.AuthConstant;
 import com.halfgallon.withcon.domain.auth.manager.JwtManager;
 import com.halfgallon.withcon.domain.auth.repository.AccessTokenRepository;
 import com.halfgallon.withcon.domain.auth.repository.RefreshTokenRepository;
+import com.halfgallon.withcon.domain.auth.security.filter.JwtAuthenticationFilter;
 import com.halfgallon.withcon.domain.auth.security.filter.LoginFilter;
 import com.halfgallon.withcon.domain.auth.security.handler.CustomLogoutSuccessHandler;
 import com.halfgallon.withcon.domain.auth.security.handler.LoginFailureHandler;
@@ -28,6 +32,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
@@ -47,9 +52,6 @@ public class SecurityConfig {
 
   private static final AntPathRequestMatcher LOGOUT_ANT_PATH_REQUEST_MATCHER =
       new AntPathRequestMatcher("/auth/logout", "POST");
-
-  private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
-
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
@@ -77,7 +79,11 @@ public class SecurityConfig {
             .requestMatchers(LOGOUT_ANT_PATH_REQUEST_MATCHER).hasRole("USER")
             .anyRequest().permitAll()
         )
-        .addFilterBefore(loginFilter(), UsernamePasswordAuthenticationFilter.class);
+        .addFilterBefore(
+            new JwtAuthenticationFilter(memberRepository, accessTokenRepository),
+            LogoutFilter.class)
+        .addFilterBefore(loginFilter(), UsernamePasswordAuthenticationFilter.class)
+    ;
 
     return http.build();
   }

--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.halfgallon.withcon.domain.auth.security.filter;
+
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.ACCESS_TOKEN_HEADER_NAME;
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.ACCESS_TOKEN_PREFIX;
+
+import com.halfgallon.withcon.domain.auth.entity.AccessToken;
+import com.halfgallon.withcon.domain.auth.repository.AccessTokenRepository;
+import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
+import com.halfgallon.withcon.domain.member.entity.Member;
+import com.halfgallon.withcon.domain.member.repository.MemberRepository;
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.exception.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final MemberRepository memberRepository;
+  private final AccessTokenRepository accessTokenRepository;
+
+  @Override
+  public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String accessTokenHeader = request.getHeader(ACCESS_TOKEN_HEADER_NAME);
+
+    if (!StringUtils.hasText(accessTokenHeader)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    if (!accessTokenHeader.startsWith(ACCESS_TOKEN_PREFIX)) {
+      throw new CustomException(ErrorCode.ACCESS_TOKEN_NOT_SUPPORTED);
+    }
+
+    String accessToken = accessTokenHeader.substring(ACCESS_TOKEN_PREFIX.length());
+
+    AccessToken findAccessToken = accessTokenRepository.findByAccessToken(accessToken)
+        .orElseThrow(() -> new CustomException(ErrorCode.ACCESS_TOKEN_EXPIRED));
+
+    Long memberId = findAccessToken.getMemberId();
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    authenticate(member);
+    filterChain.doFilter(request, response);
+  }
+
+  private void authenticate(Member member) {
+    CustomUserDetails principal = CustomUserDetails.fromEntity(member);
+    Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "",
+        principal.getAuthorities());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/LoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.auth.security.handler;
 
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -28,8 +29,6 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
   private final AccessTokenRepository accessTokenRepository;
   private final RefreshTokenRepository refreshTokenRepository;
 
-  private static final String ACCESS_TOKEN_HEADER_NAME = "Authorization";
-  private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
   private static final int REFRESH_TOKEN_COOKIE_EXPIRY = 60 * 60 * 24 * 14;
 
   @Override
@@ -55,7 +54,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
     refreshTokenCookie.setMaxAge(REFRESH_TOKEN_COOKIE_EXPIRY);
 
     // 응답
-    response.setHeader(ACCESS_TOKEN_HEADER_NAME, accessToken);
+    response.setHeader(ACCESS_TOKEN_HEADER_NAME, ACCESS_TOKEN_PREFIX + accessToken);
     response.addCookie(refreshTokenCookie);
     response.setContentType(APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(UTF_8.name());

--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/service/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
     Member findMember = memberRepository.findByUsername(username)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
     return CustomUserDetails.fromEntity(findMember);
   }

--- a/src/main/java/com/halfgallon/withcon/domain/auth/service/AuthService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/service/AuthService.java
@@ -4,5 +4,13 @@ import com.halfgallon.withcon.domain.auth.dto.request.AuthJoinRequest;
 
 public interface AuthService {
 
+  /**
+   * 회원가입
+   */
   void join(AuthJoinRequest authJoinRequest);
+
+  /**
+   * 액세스 토큰 재발급
+   */
+  String reissueAccessToken(String refreshToken);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatMessageServiceImpl.java
@@ -1,6 +1,6 @@
 package com.halfgallon.withcon.domain.chat.service.impl;
 
-import static com.halfgallon.withcon.global.exception.ErrorCode.USER_NOT_FOUND;
+import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.halfgallon.withcon.domain.chat.constant.MessageType;
 import com.halfgallon.withcon.domain.chat.dto.ChatMessageDto;
@@ -33,7 +33,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
   public ChatMessageDto enterMessage(ChatMessageDto request, Long roomId) {
 
     Member member = memberRepository.findById(request.getMemberId())
-        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
     String message = member.getNickname() + "님이 입장하였습니다.";
 
@@ -50,7 +50,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
   public ChatMessageDto exitMessage(ChatMessageDto request, Long roomId) {
 
     Member member = memberRepository.findById(request.getMemberId())
-        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
     String message = member.getNickname() + "님이 퇴장하였습니다.";
 

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -5,7 +5,7 @@ import static com.halfgallon.withcon.global.exception.ErrorCode.CHATROOM_NOT_FOU
 import static com.halfgallon.withcon.global.exception.ErrorCode.DUPLICATE_CHATROOM;
 import static com.halfgallon.withcon.global.exception.ErrorCode.PARTICIPANT_NOT_FOUND;
 import static com.halfgallon.withcon.global.exception.ErrorCode.USER_JUST_ONE_CREATE_CHATROOM;
-import static com.halfgallon.withcon.global.exception.ErrorCode.USER_NOT_FOUND;
+import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomEnterResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomRequest;
@@ -37,7 +37,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   public ChatRoomResponse createChatRoom(ChatRoomRequest request) {
     //멤버 조회 검사(@AuthenticationPrincipal) -> 임시로 memberRepository에서 들고와서 진행
     Member member = memberRepository.findById(request.memberId())
-        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
     validationCreateChatroom(request);
 
@@ -65,7 +65,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   public ChatRoomEnterResponse enterChatRoom(Long chatRoomId, Long memberId) {
     //멤버 조회 검사(@AuthenticationPrincipal) -> 임시 멤버 생성
     Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
         .orElseThrow(() -> new CustomException(CHATROOM_NOT_FOUND));
@@ -98,7 +98,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Transactional
   public void exitChatRoom(Long chatRoomId, Long memberId) {
     Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
         .orElseThrow(() -> new CustomException(CHATROOM_NOT_FOUND));

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,15 +21,20 @@ public enum ErrorCode {
   USER_JUST_ONE_CREATE_CHATROOM(BAD_REQUEST.value(), "채팅방은 1인당 1개만 생성 가능합니다."),
   METHOD_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Method 요청입니다."),
   CONTENT_TYPE_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Content-type 요청입니다."),
+  ACCESS_TOKEN_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 액세스 토큰 요청입니다."),
+  REFRESH_TOKEN_COOKIE_IS_EMPTY(BAD_REQUEST.value(), "리프래시 토큰 쿠키가 없는 요청입니다."),
+  JWT_PARSE_ERROR(BAD_REQUEST.value(), "만료되었거나 유효하지 않은 JWT 토큰 입니다."),
+
   /**
    * 401 Unauthorized
    */
-
+  ACCESS_TOKEN_EXPIRED(UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다."),
+  REFRESH_TOKEN_EXPIRED(UNAUTHORIZED.value(), "리프래시 토큰이 만료되었습니다."),
 
   /**
    * 404 Not Found
    */
-  USER_NOT_FOUND(NOT_FOUND.value(), "유저가 아닙니다"),
+  MEMBER_NOT_FOUND(NOT_FOUND.value(), "존재하지 않는 회원입니다."),
   CHATROOM_NOT_FOUND(NOT_FOUND.value(), "채팅방이 생성되지 않았습니다."),
   PARTICIPANT_NOT_FOUND(NOT_FOUND.value(), "해당 채팅방 참여자가 아닙니다."),
 

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -21,15 +21,16 @@ public enum ErrorCode {
   USER_JUST_ONE_CREATE_CHATROOM(BAD_REQUEST.value(), "채팅방은 1인당 1개만 생성 가능합니다."),
   METHOD_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Method 요청입니다."),
   CONTENT_TYPE_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Content-type 요청입니다."),
-  ACCESS_TOKEN_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 액세스 토큰 요청입니다."),
-  REFRESH_TOKEN_COOKIE_IS_EMPTY(BAD_REQUEST.value(), "리프래시 토큰 쿠키가 없는 요청입니다."),
-  JWT_PARSE_ERROR(BAD_REQUEST.value(), "만료되었거나 유효하지 않은 JWT 토큰 입니다."),
+
 
   /**
    * 401 Unauthorized
    */
   ACCESS_TOKEN_EXPIRED(UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다."),
   REFRESH_TOKEN_EXPIRED(UNAUTHORIZED.value(), "리프래시 토큰이 만료되었습니다."),
+  ACCESS_TOKEN_NOT_SUPPORTED(UNAUTHORIZED.value(), "잘못된 액세스 토큰 요청입니다."),
+  REFRESH_TOKEN_COOKIE_IS_EMPTY(UNAUTHORIZED.value(), "리프래시 토큰 쿠키가 없는 요청입니다."),
+  JWT_PARSE_ERROR(UNAUTHORIZED.value(), "만료되었거나 유효하지 않은 JWT 토큰 입니다."),
 
   /**
    * 404 Not Found

--- a/src/test/java/com/halfgallon/withcon/domain/auth/api/LoginTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/api/LoginTest.java
@@ -1,5 +1,7 @@
 package com.halfgallon.withcon.domain.auth.api;
 
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.ACCESS_TOKEN_HEADER_NAME;
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.REFRESH_TOKEN_COOKIE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -118,8 +120,8 @@ class LoginTest {
     mockMvc.perform(post(LOGIN_PATH)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(loginRequest)))
-        .andExpect(header().exists("Authorization"))
-        .andExpect(cookie().exists("refresh_token"))
+        .andExpect(header().exists(ACCESS_TOKEN_HEADER_NAME))
+        .andExpect(cookie().exists(REFRESH_TOKEN_COOKIE_NAME))
         .andExpect(status().isOk());
   }
 
@@ -140,8 +142,8 @@ class LoginTest {
     mockMvc.perform(post(LOGIN_PATH)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(loginRequest)))
-        .andExpect(header().exists("Authorization"))
-        .andExpect(cookie().exists("refresh_token"))
+        .andExpect(header().exists(ACCESS_TOKEN_HEADER_NAME))
+        .andExpect(cookie().exists(REFRESH_TOKEN_COOKIE_NAME))
         .andExpect(status().isOk());
 
     boolean existAccessToken = accessTokenRepository.findById(savedMember.getId())

--- a/src/test/java/com/halfgallon/withcon/domain/auth/api/LogoutTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/api/LogoutTest.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.auth.api;
 
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.REFRESH_TOKEN_COOKIE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
@@ -65,7 +66,7 @@ class LogoutTest {
   @DisplayName("로그아웃 시 리프래시 토큰 쿠키가 삭제된다.")
   void logout_Success_Will_Delete_RefreshTokenCookie() throws Exception {
     // given
-    Cookie requestCookie = new Cookie("refresh_token", "refreshToken");
+    Cookie requestCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, "refreshToken");
     requestCookie.setMaxAge(500);
 
     // when
@@ -73,6 +74,6 @@ class LogoutTest {
     mockMvc.perform(post(LOGOUT_PATH)
             .cookie(requestCookie))
         .andExpect(status().isOk())
-        .andExpect(cookie().maxAge("refresh_token", 0));
+        .andExpect(cookie().maxAge(REFRESH_TOKEN_COOKIE_NAME, 0));
   }
 }

--- a/src/test/java/com/halfgallon/withcon/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/controller/AuthControllerTest.java
@@ -74,7 +74,7 @@ class AuthControllerTest {
   @Test
   @DisplayName("액세스토큰 재발급 요청")
   void reissueAccessToken_Success() throws Exception {
-    String refreshToken = "Bearer RefreshToken";
+    String refreshToken = "RefreshToken";
 
     mockMvc.perform(post("/auth/reissue")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/halfgallon/withcon/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/controller/AuthControllerTest.java
@@ -1,14 +1,18 @@
 package com.halfgallon.withcon.domain.auth.controller;
 
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.ACCESS_TOKEN_HEADER_NAME;
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.REFRESH_TOKEN_COOKIE_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.halfgallon.withcon.domain.auth.dto.request.AuthJoinRequest;
 import com.halfgallon.withcon.domain.auth.service.AuthService;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,5 +69,19 @@ class AuthControllerTest {
         .andExpect(status().isCreated());
 
     verify(authService, times(1)).join(any(AuthJoinRequest.class));
+  }
+
+  @Test
+  @DisplayName("액세스토큰 재발급 요청")
+  void reissueAccessToken_Success() throws Exception {
+    String refreshToken = "Bearer RefreshToken";
+
+    mockMvc.perform(post("/auth/reissue")
+            .contentType(MediaType.APPLICATION_JSON)
+            .cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken)))
+        .andExpect(header().exists(ACCESS_TOKEN_HEADER_NAME))
+        .andExpect(status().isOk());
+
+    verify(authService, times(1)).reissueAccessToken(refreshToken);
   }
 }

--- a/src/test/java/com/halfgallon/withcon/domain/auth/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/security/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,164 @@
+package com.halfgallon.withcon.domain.auth.security.filter;
+
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.halfgallon.withcon.domain.auth.entity.AccessToken;
+import com.halfgallon.withcon.domain.auth.repository.AccessTokenRepository;
+import com.halfgallon.withcon.domain.member.entity.Member;
+import com.halfgallon.withcon.domain.member.repository.MemberRepository;
+import com.halfgallon.withcon.global.exception.CustomException;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+public class JwtAuthenticationFilterTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private AccessTokenRepository accessTokenRepository;
+
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  @BeforeEach
+  public void setUp() {
+    jwtAuthenticationFilter = new JwtAuthenticationFilter(memberRepository, accessTokenRepository);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("헤더에 액세스토큰이 없는 요청이면 다음 필터를 호출한다.")
+  public void doFilterInternal_Access_Token_empty()
+      throws ServletException, IOException {
+
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, chain);
+
+    // then
+    assertThat(chain.getRequest()).isEqualTo(request);
+    assertThat(chain.getResponse()).isEqualTo(response);
+  }
+
+  @Test
+  @DisplayName("❗헤더에 액세스토큰이 있지만 'Bearer' 로 시작하지 않으면 실패한다.")
+  public void doFilterInternal_Fail_Access_Token_Prefix_Is_Not_Bearer()
+      throws ServletException, IOException {
+
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(ACCESS_TOKEN_HEADER_NAME, "No Bearer AccessToken");
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    // when
+    // then
+    assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(request, response, chain))
+        .isInstanceOf(CustomException.class)
+        .hasMessageContaining("잘못된 액세스 토큰 요청입니다.");
+  }
+
+  @Test
+  @DisplayName("❗헤더의 액세스 토큰이 저장된 액세스 토큰이 아니면 액세스 토큰이 만료되었다고 응답한다.")
+  public void doFilterInternal_Fail_Access_Token_Expired()
+      throws ServletException, IOException {
+
+    String accessTokenValue = "AccessToken";
+
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(ACCESS_TOKEN_HEADER_NAME, ACCESS_TOKEN_PREFIX + accessTokenValue);
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    // when
+    // then
+    assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(request, response, chain))
+        .isInstanceOf(CustomException.class)
+        .hasMessageContaining("액세스 토큰이 만료되었습니다.");
+  }
+
+  @Test
+  @DisplayName("❗헤더의 액세스 토큰의 주인이 존재하지 않는 회원이면 예외를 던진다.")
+  public void doFilterInternal_Fail_Member_Not_Found()
+      throws ServletException, IOException {
+
+    // given
+    String accessTokenValue = "AccessToken";
+    AccessToken accessToken = new AccessToken(1L, accessTokenValue);
+
+    given(accessTokenRepository.findByAccessToken(accessTokenValue)).willReturn(
+        Optional.of(accessToken));
+    given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(ACCESS_TOKEN_HEADER_NAME, ACCESS_TOKEN_PREFIX + accessTokenValue);
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    // when
+    // then
+    assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(request, response, chain))
+        .isInstanceOf(CustomException.class)
+        .hasMessageContaining("존재하지 않는 회원입니다.");
+  }
+
+  @Test
+  @DisplayName("액세스 토큰 검증에 성공하면 인증 객체가 시큐리티 컨텍스트에 저장된다.")
+  public void doFilterInternal_Success()
+      throws ServletException, IOException {
+
+    // given
+    String accessTokenValue = "AccessToken";
+    AccessToken accessToken = new AccessToken(1L, accessTokenValue);
+
+    Member member = Member.builder().id(1L).build();
+
+    given(accessTokenRepository.findByAccessToken(accessTokenValue)).willReturn(
+        Optional.of(accessToken));
+    given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(ACCESS_TOKEN_HEADER_NAME, ACCESS_TOKEN_PREFIX + accessTokenValue);
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, chain);
+
+    // then
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isNotNull();
+    assertThat(chain.getRequest()).isEqualTo(request);
+    assertThat(chain.getResponse()).isEqualTo(response);
+  }
+}


### PR DESCRIPTION
## 📝작업 내용

> 토큰 검증 및 액세스 토큰 재발급 API 추가
- 공통으로 사용되는 상수들을 쉽게 관리하고자 AuthConstant 클래스를 작성했습니다.("Authorization", "Bearer " 등)
- JwtAuthenticationFilter를 작성하여 모든 요청마다 액세스 토큰을 검증합니다.
- 만료된 액세스 토큰일 시, 클라이언트는 /auth/reissue POST (액세스 토큰 재발급) 요청을 합니다.
- 액세스 토큰 재발급 API는 리프래시 토큰 쿠키를 검증하고 만료됐으면 만료 응답을, 유효하면 재발급과 동시에 Redis에 재발급된 액세스 토큰을 저장합니다.

## 💬리뷰 참고사항

## #️⃣연관된 이슈

(close) #20 
