### PR TITLE
[fix] mysql 컨테이너 설정 변경

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: always
     container_name: withcon-mysql
     env_file:
-      - /home/ec2-user/.env
+      - .env
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:


### PR DESCRIPTION
mysql 컨테이너의 환경변수 설정 파일의 경로 변경

## 📝작업 내용
jenkins 컨테이너 내부에서 호스트의 디렉토리에 접근할 수 없으므로 경로 변경


## 💬리뷰 참고사항

기존에는 호스트의 디렉토리 경로를 사용했으나 젠킨스 컨테이너 내부에서 접근 불가하므로 현재 작업 디렉토리의 .env 파일에서 환경 변수를 로드하게 변경



## #️⃣연관된 이슈
#24 

