### PR TITLE
[feat] 태그 이름 검색 시 태그 갯수가 많은 순으로 조회 

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
@@ -4,6 +4,7 @@ import com.halfgallon.withcon.domain.tag.service.TagService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,7 +15,6 @@ public class TagController {
 
   private final TagService tagService;
 
-
   /**
    * 태그 정보 조회(태그 갯수 많은 순으로 정렬)
    * @return : name(태그 이름), count(태그 생성 갯수)
@@ -22,6 +22,15 @@ public class TagController {
   @GetMapping("/search")
   public ResponseEntity<?> findTagOrderByCount() {
     return ResponseEntity.ok(tagService.findTagOrderByCount());
+  }
+
+  /**
+   * 태그 이름 검색 시에 태그 갯수가 많은 순으로 정렬
+   * @return : name(태그 이름), count(태그 생성 갯수)
+   */
+  @GetMapping("/{tagName}/search")
+  public ResponseEntity<?> findTagNameOrderByCount(@PathVariable("tagName") String tagName) {
+    return ResponseEntity.ok(tagService.findTagNameOrderByCount(tagName));
   }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/CustomTagRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/CustomTagRepository.java
@@ -7,4 +7,5 @@ public interface CustomTagRepository {
 
   List<TagCountDto> findTagOrderByCount();
 
+  List<TagCountDto> findTagNameOrderByCount(String name);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagRepositoryImpl.java
@@ -28,4 +28,18 @@ public class CustomTagRepositoryImpl implements CustomTagRepository {
         .fetch();
   }
 
+  @Override
+  public List<TagCountDto> findTagNameOrderByCount(String name) {
+    return jpaQueryFactory.select(
+            Projections.fields(TagCountDto.class,
+                tag.name,
+                tag.count().as("count")))
+        .from(tag)
+        .where(tag.name.contains(name))
+        .groupBy(tag.name)
+        .orderBy(tag.count().desc())
+        .limit(10)
+        .fetch();
+  }
+
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/service/TagService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/service/TagService.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface TagService {
 
   List<TagCountDto> findTagOrderByCount();
+
+  List<TagCountDto> findTagNameOrderByCount(String tagName);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/service/TagServiceImpl.java
@@ -19,4 +19,10 @@ public class TagServiceImpl implements TagService {
     return tagRepository.findTagOrderByCount();
   }
 
+  @Override
+  @Transactional(readOnly = true)
+  public List<TagCountDto> findTagNameOrderByCount(String tagName) {
+    return tagRepository.findTagNameOrderByCount(tagName);
+  }
+
 }

--- a/src/test/http/tag.http
+++ b/src/test/http/tag.http
@@ -1,3 +1,11 @@
-### 태그 정보 조회(태그 갯수 정렬)
-GET http://localhost:8080/tag
+### 태그 정보 조회(태그 갯수가 많은 순으로 정렬)
+GET http://localhost:8080/tag/search
+Content-Type: application/json
+
+
+### 태그 이름 검색(태그 갯수가 많은 순으로 정렬)
+< {%
+  request.variables.set("tags", "번")
+%}
+GET http://localhost:8080/tag/{{tags}}/search
 Content-Type: application/json

--- a/src/test/java/com/halfgallon/withcon/domain/tag/repository/TagRepositoryTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/tag/repository/TagRepositoryTest.java
@@ -51,4 +51,36 @@ class TagRepositoryTest {
     assertThat(tagOrderByCount.get(0).getCount()).isEqualTo(5);
     assertThat(tagOrderByCount.get(0).getName()).isEqualTo("#1번채팅방");
   }
+
+
+  @Test
+  @DisplayName("태그 이름 검색 - 태그 갯수가 많은 순으로 정렬")
+  void findTagNameOrderByCount() {
+    //given
+    for (int i = 0; i < 2; i++) {
+      tagRepository.save(Tag.builder()
+          .name("위드콘")
+          .build());
+    }
+
+    tagRepository.save(Tag.builder()
+        .name("위드")
+        .build());
+
+    tagRepository.save(Tag.builder()
+        .name("콘서트")
+        .build());
+
+    tagRepository.save(Tag.builder()
+        .name("월드콘")
+        .build());
+
+    //when
+    List<TagCountDto> response = tagRepository.findTagNameOrderByCount("콘");
+
+    //then
+    assertThat(response.isEmpty()).isFalse();
+    assertThat(response.size()).isEqualTo(3);
+    assertThat(response.get(0).getName()).isEqualTo("위드콘");
+  }
 }


### PR DESCRIPTION
## 📝작업 내용
1. 태그 이름 검색하는 API 생성
     - 태그 이름을 검색하면 해당 태그 이름을 가지고 있는 데이터를 `태그 갯수` 순으로 정렬하여 10개를 조회한다.
     - 쿼리문 작성 시에 `DTO` 를 이용하여 `QueryDsl` 문으로 작성
 
2. 태그 이름 검색 - 태그 갯수가 많은 순으로 정렬
     - 태그 데이터을 임의로 저장한다.
     - 태그 데이터를 쿼리문을 이용하여 조회한다.
     - 해당 데이터의 유/무 및 데이터에 대한 검증을 진행한다.
 
## 💬리뷰 참고사항

- 해당 테스트 코드 결과

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/c939c440-85cc-4164-a5a6-47c5022f5a39)

- 해당 API 테스트 결과

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/715f3ec5-8220-4bd2-87b1-9ed226f3a40a)


## #️⃣연관된 이슈
close #40 
