### PR TITLE
[fix] nginx 컨테이너 마운트 경로 수정

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: mysql:latest
     command: --default-authentication-plugin=mysql_native_password
     restart: always
-    container_name: withcon-mysql
+    container_name: mysql
     env_file:
       - .env
     environment:
@@ -36,11 +36,11 @@ services:
 
   nginx:
     image: nginx:latest
-    container_name: withcon-nginx
+    container_name: nginx
     ports:
       - "80:80"
     volumes:
-      - ./config/nginx.conf:/etc/nginx/nginx.conf
+      - /home/ec2-user/config/nginx.conf:/etc/nginx/nginx.conf
     restart: always
     networks:
       - withcon


### PR DESCRIPTION
## 📝작업 내용

- nginx 컨테이너 마운트 경로 수정


## 💬리뷰 참고사항

- ./config/nginx.conf 파일을 컨테이너의 /etc/nginx/nginx.conf에 마운트하도록 설정되어 있습니다. 
그러나 실제 nginx.conf 파일은 /home/ec2-user/config에 위치해 있으므로, 이 경로를 수정했습니다.


## #️⃣연관된 이슈

#37 
