### PR TITLE
[refactor] 채팅서비스 코드 리팩토링 진행

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatParticipantRepository.java
@@ -1,18 +1,12 @@
 package com.halfgallon.withcon.domain.chat.repository;
 
 import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
-import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
-import com.halfgallon.withcon.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long>, CustomChatParticipantRepository {
-
-  boolean existsByMemberId(Long MemberId);
-
-  boolean existsByMemberIdAndChatRoomId(Long memberId, Long roomId);
-
-  Optional<ChatParticipant> findByMemberAndChatRoom(Member member, ChatRoom chatRoom);
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long>,
+    CustomChatParticipantRepository {
+  Optional<ChatParticipant> findByMemberIdAndChatRoomId(Long memberId, Long roomId);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImpl.java
@@ -1,11 +1,8 @@
 package com.halfgallon.withcon.domain.chat.service.impl;
 
-import static com.halfgallon.withcon.global.exception.ErrorCode.USER_NOT_PARTICIPANT_CHATTING;
-
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantResponse;
 import com.halfgallon.withcon.domain.chat.repository.ChatParticipantRepository;
 import com.halfgallon.withcon.domain.chat.service.ChatParticipantService;
-import com.halfgallon.withcon.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,10 +18,6 @@ public class ChatParticipantServiceImpl implements ChatParticipantService {
   @Override
   @Transactional(readOnly = true)
   public Page<ChatParticipantResponse> findMyChatRoom(Long memberId, Pageable pageable) {
-    if (!chatParticipantRepository.existsByMemberId(memberId)) {
-      throw new CustomException(USER_NOT_PARTICIPANT_CHATTING);
-    }
-
     return chatParticipantRepository.findAllMyChattingRoom(memberId, pageable)
         .map(ChatParticipantResponse::fromEntity);
   }

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -3,9 +3,9 @@ POST http://localhost:8080/chatRoom
 Content-Type: application/json
 
 {
-  "memberId": 7,
-  "name": "7번채팅방",
-  "tags": ["#3번", "#7번"]
+  "memberId": 8,
+  "name": "8번채팅방",
+  "tags": ["#3번", "#6번", "#10번"]
 }
 
 ### 채팅방 조회
@@ -13,9 +13,9 @@ GET http://localhost:8080/chatRoom
 Content-Type: application/json
 
 ### 채팅방 입장
-GET http://localhost:8080/chatRoom/7/enter?memberId=2
+GET http://localhost:8080/chatRoom/3/enter?memberId=7
 Content-Type: application/json
 
 ### 채팅방 퇴장
-DELETE http://localhost:8080/chatRoom/5/exit?memberId=1
+DELETE http://localhost:8080/chatRoom/3/exit?memberId=7
 Content-Type: application/json

--- a/src/test/http/tag.http
+++ b/src/test/http/tag.http
@@ -5,7 +5,7 @@ Content-Type: application/json
 
 ### 태그 이름 검색(태그 갯수가 많은 순으로 정렬)
 < {%
-  request.variables.set("tags", "번")
+  request.variables.set("tags", "위드")
 %}
 GET http://localhost:8080/tag/{{tags}}/search
 Content-Type: application/json

--- a/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImplTest.java
@@ -1,9 +1,7 @@
 package com.halfgallon.withcon.domain.chat.service.impl;
 
-import static com.halfgallon.withcon.global.exception.ErrorCode.USER_NOT_PARTICIPANT_CHATTING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantResponse;
@@ -11,9 +9,7 @@ import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
 import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
 import com.halfgallon.withcon.domain.chat.repository.ChatParticipantRepository;
 import com.halfgallon.withcon.domain.member.entity.Member;
-import com.halfgallon.withcon.global.exception.CustomException;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,36 +28,14 @@ class ChatParticipantServiceImplTest {
 
   @InjectMocks
   ChatParticipantServiceImpl chatParticipantService;
-
   @Mock
   ChatParticipantRepository chatParticipantRepository;
-
-
-  @Test
-  @DisplayName("나의 채팅방 조회 실패 - 참여하는 채팅이 없음")
-  void findMyChatRoom_FailByExistsMember() {
-    //given
-    given(chatParticipantRepository.existsByMemberId(anyLong()))
-        .willReturn(false);
-
-    Pageable pageable = PageRequest.of(0, 5, Sort.by(Direction.DESC, "id"));
-
-    //when
-    CustomException customException = Assertions.assertThrows(CustomException.class,
-        () -> chatParticipantService.findMyChatRoom(1L, pageable));
-
-    //then
-    assertThat(USER_NOT_PARTICIPANT_CHATTING.getDescription()).isEqualTo(customException.getMessage());
-  }
 
   @Test
   @DisplayName("나의 채팅방 조회 성공")
   void findMyChatRoom_Success() {
     //given
     Pageable pageable = PageRequest.of(0, 5, Sort.by(Direction.DESC, "id"));
-
-    given(chatParticipantRepository.existsByMemberId(anyLong()))
-        .willReturn(true);
 
     given(chatParticipantRepository.findAllMyChattingRoom(1L, pageable))
         .willReturn(new PageImpl<>(List.of(ChatParticipant.builder()
@@ -85,5 +59,22 @@ class ChatParticipantServiceImplTest {
 
     //then
     assertTrue(responses.hasContent());
+  }
+
+  @Test
+  @DisplayName("나의 채팅방 조회 - 참여하고 있는 채팅방이 없습니다.")
+  void findMyChatRoom_NotParticipant() {
+    //given
+    Pageable pageable = PageRequest.of(0, 5, Sort.by(Direction.DESC, "id"));
+
+    given(chatParticipantRepository.findAllMyChattingRoom(1L, pageable))
+        .willReturn(Page.empty());
+
+    //when
+    Page<ChatParticipantResponse> responses
+        = chatParticipantService.findMyChatRoom(1L, pageable);
+
+    //then
+    assertThat(responses.hasContent()).isFalse();
   }
 }

--- a/src/test/java/com/halfgallon/withcon/domain/tag/repository/TagRepositoryTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/tag/repository/TagRepositoryTest.java
@@ -79,8 +79,7 @@ class TagRepositoryTest {
     List<TagCountDto> response = tagRepository.findTagNameOrderByCount("콘");
 
     //then
-    assertThat(response.isEmpty()).isFalse();
-    assertThat(response.size()).isEqualTo(3);
+    assertThat(response.size()).isNotZero();
     assertThat(response.get(0).getName()).isEqualTo("위드콘");
   }
 }


### PR DESCRIPTION
## 📝작업 내용
1. 채팅서비스 코드 리팩토링 진행
    - 나의 채팅방 조회 시에 `existsByMemberId` 밸리데이션 체크 삭제
    - 채팅방 생성 코드 리팩토링
      - 태그 유무 null 체크 -> `CollectionUtils.isEmpty()` 변경
      - tagList 저장 시 `forEach` -> `for`문으로 변경
    - 채팅방 입장 코드 리팩토링
      - 동일 인물 중복 입장 밸리데이션 삭제 -> 채팅방에 참여중인 사람인 경우에만 채팅참여자로 확인(더블 클릭 및 중복 확인)
    - 채팅방 퇴장 코드 리팩토링
      - 불필요한 `findBy` 메서드 삭제
      - 양방향 매핑을 이용한 메서드 적용

2. 코드 리팩토링에 따른 테스트 코드 작성

## 💬리뷰 참고사항
_No_Response_

## #️⃣연관된 이슈
close: #47