### PR TITLE
[refactor] 채팅서비스 CustomUserDetails 적용 및 ErrorCode 반환값 변경

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/LoginFailureHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/LoginFailureHandler.java
@@ -1,12 +1,13 @@
 package com.halfgallon.withcon.domain.auth.security.handler;
 
+import static com.halfgallon.withcon.global.exception.ErrorCode.LOGIN_FAILURE_MESSAGE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halfgallon.withcon.global.exception.ErrorCode;
 import com.halfgallon.withcon.global.exception.ErrorResponse;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -20,14 +21,15 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 public class LoginFailureHandler implements AuthenticationFailureHandler {
 
   private final ObjectMapper objectMapper;
-  private static final String LOGIN_FAILURE_MESSAGE = "아이디 혹은 비밀번호가 올바르지 않습니다.";
 
   @Override
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-      AuthenticationException exception) throws IOException, ServletException {
+      AuthenticationException exception) throws IOException {
     log.info("로그인 실패");
 
-    ErrorResponse errorResponse = new ErrorResponse(BAD_REQUEST.value(), LOGIN_FAILURE_MESSAGE);
+    //test
+    ErrorResponse errorResponse = new ErrorResponse(BAD_REQUEST.value(),
+        ErrorCode.LOGIN_FAILURE_MESSAGE, LOGIN_FAILURE_MESSAGE.getDescription());
 
     response.setContentType(APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(UTF_8.name());

--- a/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatParticipantController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatParticipantController.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.chat.controller;
 
+import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantResponse;
 import com.halfgallon.withcon.domain.chat.service.ChatParticipantService;
 import lombok.RequiredArgsConstructor;
@@ -7,8 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,10 +18,11 @@ public class ChatParticipantController {
 
   private final ChatParticipantService chatParticipantService;
 
-  @GetMapping("/chatRoom/members/{memberId}")
+  @GetMapping("/chatRoom/member")
   public ResponseEntity<Page<ChatParticipantResponse>> findMyChatRoom(
-      @PathVariable("memberId") Long memberId, @PageableDefault(size = 5) Pageable pageable) {
-    return ResponseEntity.ok(chatParticipantService.findMyChatRoom(memberId, pageable));
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PageableDefault(size = 5) Pageable pageable) {
+    return ResponseEntity.ok(chatParticipantService.findMyChatRoom(customUserDetails, pageable));
   }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.chat.controller;
 
+import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomEnterResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomRequest;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomResponse;
@@ -11,12 +12,12 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,8 +27,11 @@ public class ChatRoomController {
   private final ChatRoomService chatRoomService;
 
   @PostMapping("/chatRoom")
-  public ResponseEntity<ChatRoomResponse> createChatRoom(@RequestBody ChatRoomRequest request) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(chatRoomService.createChatRoom(request));
+  public ResponseEntity<ChatRoomResponse> createChatRoom(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @RequestBody ChatRoomRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        chatRoomService.createChatRoom(customUserDetails ,request));
   }
 
   @GetMapping("/chatRoom")
@@ -38,14 +42,15 @@ public class ChatRoomController {
 
   @GetMapping("/chatRoom/{chatRoomId}/enter")
   public ResponseEntity<ChatRoomEnterResponse> enterChatRoom(
-      @PathVariable("chatRoomId") Long chatRoomId, @RequestParam Long memberId) {
-    return ResponseEntity.ok(chatRoomService.enterChatRoom(chatRoomId, memberId));
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable("chatRoomId") Long chatRoomId) {
+    return ResponseEntity.ok(chatRoomService.enterChatRoom(customUserDetails, chatRoomId));
   }
 
   @DeleteMapping("/chatRoom/{chatRoomId}/exit")
-  public ResponseEntity<?> exitChatRoom(@PathVariable("chatRoomId") Long chatRoomId,
-                                        @RequestParam Long memberId) {
-    chatRoomService.exitChatRoom(chatRoomId, memberId);
+  public ResponseEntity<?> exitChatRoom(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                        @PathVariable("chatRoomId") Long chatRoomId) {
+    chatRoomService.exitChatRoom(customUserDetails, chatRoomId);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
@@ -4,7 +4,6 @@ import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
 import java.util.List;
 
 public record ChatRoomRequest(
-    Long memberId,
     String name,
     List<String> tags
 ) {

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatParticipantService.java
@@ -1,10 +1,11 @@
 package com.halfgallon.withcon.domain.chat.service;
 
+import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ChatParticipantService {
 
-  Page<ChatParticipantResponse> findMyChatRoom(Long memberId, Pageable pageable);
+  Page<ChatParticipantResponse> findMyChatRoom(CustomUserDetails customUserDetails, Pageable pageable);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatRoomService.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.chat.service;
 
+import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomEnterResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomRequest;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomResponse;
@@ -8,11 +9,11 @@ import org.springframework.data.domain.Pageable;
 
 public interface ChatRoomService {
 
-  ChatRoomResponse createChatRoom(ChatRoomRequest request);
+  ChatRoomResponse createChatRoom(CustomUserDetails customUserDetails, ChatRoomRequest request);
 
   Page<ChatRoomResponse> findChatRoom(Pageable pageable);
 
-  ChatRoomEnterResponse enterChatRoom(Long chatRoomId, Long memberId);
+  ChatRoomEnterResponse enterChatRoom(CustomUserDetails customUserDetails, Long chatRoomId);
 
-  void exitChatRoom(Long chatRoomId, Long memberId);
+  void exitChatRoom(CustomUserDetails customUserDetails, Long chatRoomId);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImpl.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.chat.service.impl;
 
+import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantResponse;
 import com.halfgallon.withcon.domain.chat.repository.ChatParticipantRepository;
 import com.halfgallon.withcon.domain.chat.service.ChatParticipantService;
@@ -17,8 +18,8 @@ public class ChatParticipantServiceImpl implements ChatParticipantService {
 
   @Override
   @Transactional(readOnly = true)
-  public Page<ChatParticipantResponse> findMyChatRoom(Long memberId, Pageable pageable) {
-    return chatParticipantRepository.findAllMyChattingRoom(memberId, pageable)
+  public Page<ChatParticipantResponse> findMyChatRoom(CustomUserDetails customUserDetails, Pageable pageable) {
+    return chatParticipantRepository.findAllMyChattingRoom(customUserDetails.getId(), pageable)
         .map(ChatParticipantResponse::fromEntity);
   }
 

--- a/src/main/java/com/halfgallon/withcon/global/exception/CustomException.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/CustomException.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
 
-  private final int statusCode;
+  private final ErrorCode errorCode;
 
   public CustomException(ErrorCode errorCode) {
     super(errorCode.getDescription());
-    statusCode = errorCode.getStatus();
+    this.errorCode = errorCode;
   }
 }

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -1,8 +1,8 @@
 package com.halfgallon.withcon.global.exception;
 
-import static org.springframework.http.HttpStatus.CONTINUE;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.CONTINUE;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
@@ -21,7 +21,7 @@ public enum ErrorCode {
   USER_JUST_ONE_CREATE_CHATROOM(BAD_REQUEST.value(), "채팅방은 1인당 1개만 생성 가능합니다."),
   METHOD_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Method 요청입니다."),
   CONTENT_TYPE_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Content-type 요청입니다."),
-
+  LOGIN_FAILURE_MESSAGE(BAD_REQUEST.value(), "아이디 혹은 비밀번호가 올바르지 않습니다."),
 
   /**
    * 401 Unauthorized

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorResponse.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorResponse.java
@@ -2,6 +2,7 @@ package com.halfgallon.withcon.global.exception;
 
 public record ErrorResponse(
     int status,
+    ErrorCode errorCode,
     String message
 ) {
 

--- a/src/main/java/com/halfgallon/withcon/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/GlobalExceptionHandler.java
@@ -12,21 +12,23 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(CustomException.class)
   public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-    ErrorResponse errorResponse = new ErrorResponse(e.getStatusCode(), e.getMessage());
+    ErrorResponse errorResponse = new ErrorResponse(
+        e.getErrorCode().getStatus(), e.getErrorCode(), e.getMessage());
     return ResponseEntity.status(errorResponse.status()).body(errorResponse);
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
       MethodArgumentNotValidException e) {
-    ErrorResponse errorResponse = new ErrorResponse(e.getStatusCode().value(), e.getMessage());
+    ErrorResponse errorResponse = new ErrorResponse(
+        e.getStatusCode().value(), ErrorCode.METHOD_NOT_SUPPORTED, e.getMessage());
     return ResponseEntity.status(errorResponse.status()).body(errorResponse);
   }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
-    ErrorResponse errorResponse = new ErrorResponse(INTERNAL_SERVER_ERROR.value(), e.getMessage());
-
+    ErrorResponse errorResponse = new ErrorResponse(
+        INTERNAL_SERVER_ERROR.value(), ErrorCode.INTERVAL_SERVER_ERROR, e.getMessage());
     return ResponseEntity.status(errorResponse.status()).body(errorResponse);
   }
 }

--- a/src/test/http/auth.http
+++ b/src/test/http/auth.http
@@ -1,0 +1,25 @@
+### 회원가입
+POST http://localhost:8080/auth/join
+Content-Type: application/json
+
+{
+  "username": "qwer1234",
+  "password": "1q2w3e4r!",
+  "email": "with00@test.com",
+  "nickname": "위드콘2",
+  "phoneNumber": "010-1924-4567"
+}
+
+### 로그인
+POST http://localhost:8080/auth/login
+Content-Type: application/json
+
+{
+  "username": "qwer1234",
+  "password": "1q2w3e4r!"
+}
+
+> {%
+  client.global.set("accessToken", response.headers.valueOf("Authorization"))
+  client.log("엑세스 토큰: " + client.global.get("accessToken"));
+  %}

--- a/src/test/http/chatParticipant.http
+++ b/src/test/http/chatParticipant.http
@@ -1,3 +1,4 @@
 ### 나의 채팅방 조회
-GET http://localhost:8080/chatRoom/members/1
+GET http://localhost:8080/chatRoom/member
 Content-Type: application/json
+Authorization: {{accessToken}}

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -1,6 +1,7 @@
 ### 채팅방 생성
 POST http://localhost:8080/chatRoom
 Content-Type: application/json
+Authorization: {{accessToken}}
 
 {
   "memberId": 8,
@@ -13,9 +14,11 @@ GET http://localhost:8080/chatRoom
 Content-Type: application/json
 
 ### 채팅방 입장
-GET http://localhost:8080/chatRoom/3/enter?memberId=7
+GET http://localhost:8080/chatRoom/5/enter
 Content-Type: application/json
+Authorization: {{accessToken}}
 
 ### 채팅방 퇴장
-DELETE http://localhost:8080/chatRoom/3/exit?memberId=7
+DELETE http://localhost:8080/chatRoom/3/exit
 Content-Type: application/json
+Authorization: {{accessToken}}

--- a/src/test/java/com/halfgallon/withcon/domain/auth/api/LoginTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/api/LoginTest.java
@@ -16,6 +16,7 @@ import com.halfgallon.withcon.domain.auth.security.filter.LoginFilter.LoginReque
 import com.halfgallon.withcon.domain.member.constant.LoginType;
 import com.halfgallon.withcon.domain.member.entity.Member;
 import com.halfgallon.withcon.domain.member.repository.MemberRepository;
+import com.halfgallon.withcon.global.exception.ErrorCode;
 import com.halfgallon.withcon.global.exception.ErrorResponse;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -70,7 +71,8 @@ class LoginTest {
     LoginRequest loginRequest = new LoginRequest("error-username", "password");
 
     ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(),
-        "아이디 혹은 비밀번호가 올바르지 않습니다.");
+        ErrorCode.LOGIN_FAILURE_MESSAGE, ErrorCode.LOGIN_FAILURE_MESSAGE.getDescription());
+
     // when
     // then
     mockMvc.perform(post(LOGIN_PATH)
@@ -93,7 +95,7 @@ class LoginTest {
     LoginRequest loginRequest = new LoginRequest("username", "error-password");
 
     ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(),
-        "아이디 혹은 비밀번호가 올바르지 않습니다.");
+        ErrorCode.LOGIN_FAILURE_MESSAGE, ErrorCode.LOGIN_FAILURE_MESSAGE.getDescription());
     // when
     // then
     mockMvc.perform(post(LOGIN_PATH)

--- a/src/test/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomControllerTest.java
@@ -14,6 +14,7 @@ import com.halfgallon.withcon.domain.chat.dto.ChatRoomEnterResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomRequest;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomResponse;
 import com.halfgallon.withcon.domain.chat.service.impl.ChatRoomServiceImpl;
+import com.halfgallon.withcon.global.annotation.WithCustomMockUser;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,15 +49,16 @@ class ChatRoomControllerTest {
   }
 
   @Test
+  @WithCustomMockUser
   @DisplayName("채팅방 생성 완료 - 태그 추가")
   void createChatRoom_withTag_Success() throws Exception {
     //given
-    given(chatRoomService.createChatRoom(any()))
+    given(chatRoomService.createChatRoom(any(), any()))
         .willReturn(getChatRoomResponse());
 
     //when
     //then
-    ChatRoomRequest request = new ChatRoomRequest(1L, "1번 채팅방",
+    ChatRoomRequest request = new ChatRoomRequest("1번 채팅방",
         List.of("#1번방", "#2번방"));
 
     mockMvc.perform(post("/chatRoom")
@@ -67,15 +69,16 @@ class ChatRoomControllerTest {
   }
 
   @Test
+  @WithCustomMockUser
   @DisplayName("채팅방 생성 완료 - 태그 제외")
   void createChatRoom_Success() throws Exception {
     //given
-    given(chatRoomService.createChatRoom(any()))
+    given(chatRoomService.createChatRoom(any(), any()))
         .willReturn(getChatRoomResponse());
 
     //when
     //then
-    ChatRoomRequest request = new ChatRoomRequest(1L, "1번 채팅방", null);
+    ChatRoomRequest request = new ChatRoomRequest("1번 채팅방", null);
 
     mockMvc.perform(post("/chatRoom")
             .contentType(MediaType.APPLICATION_JSON)
@@ -107,10 +110,11 @@ class ChatRoomControllerTest {
   }
 
   @Test
+  @WithCustomMockUser
   @DisplayName("채팅방 입장 완료")
   void enterChatRoom_success() throws Exception {
     //given
-    given(chatRoomService.enterChatRoom(anyLong(), anyLong()))
+    given(chatRoomService.enterChatRoom(any(), anyLong()))
         .willReturn(ChatRoomEnterResponse.builder()
             .chatRoomId(1L)
             .chatRoomName("1번채팅방")
@@ -119,7 +123,6 @@ class ChatRoomControllerTest {
     //when
     //then
     mockMvc.perform(get("/chatRoom/{chatRoomId}/enter",1L)
-            .param("memberId","1")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.chatRoomId").value(1L))
         .andExpect(status().isOk())


### PR DESCRIPTION
## 📝작업 내용
1. 채팅방 API 매개변수 변경
   - 채팅방 생성, 입장, 퇴장 API 매개변수 변경
   - 나의 채팅방 조회 API 매개변수 변경
       - Long memberId => @AuthenticationPrincipal CustomUserDetails customUserDetails 로 변경

2. Error Exception 변경
   - ErrorResponse ErrorCode 매개변수 추가
   - GlobalExceptionHandler ErrorCode 매개변수 추가
   - CustomException ErrorCode 매개변수 사용
  
## 💬리뷰 참고사항

- ErrorCode
  - 기존에 `status` 만을 이용해서 에러가 발생한 상태를 보고했는데 `ErrorCode`로 변환하여 
     ErrorCode에 있는 상태, 코드 이름, 메시지 모두를 반환할 수 있도록 변경

- [x] API 테스트
  - 로그인을 진행해서 `RequestHeader`로 추출된 토큰값인 `Authorization`의 값을 `accessToken`으로 설정하여 `@AuthenticationPrincipal` 를 매개변수로 사용하는 컨트롤러를 구동 시에 해당 `accessToken` 을 사용하여 제어한다.
- [x] 테스트 코드 작성
   - 기존 `memberId` 를 매개변수로 사용하는 메서드가 `CustomUserDetails` 로 매개변수를 변경했기에 
   그에 따른 기존 테스트 코드 작성 및 테스트 진행


## #️⃣연관된 이슈
close #49 #50
