### PR TITLE
[feat] 방장 강퇴 기능 구현

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatMessageController.java
@@ -40,6 +40,12 @@ public class ChatMessageController {
         chatMessageService.exitMessage(chatDto, roomId));
   }
 
+  @MessageMapping("/chat/kick/{roomId}")
+  public void kickMember(@Payload ChatMessageDto chatDto, @DestinationVariable("roomId") Long roomId) {
+    rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, "room." + roomId,
+        chatMessageService.kickMessage(chatDto, roomId));
+  }
+
   //기본적으로 chat.queue가 exchange에 바인딩 되어있기 때문에 모든 메시지 처리
   @RabbitListener(queues = ChattingConstant.CHAT_QUEUE_NAME)
   public void receive(ChatMessageDto response) {

--- a/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomController.java
@@ -56,6 +56,13 @@ public class ChatRoomController {
     return ResponseEntity.noContent().build();
   }
 
+  @DeleteMapping("/chatRoom/{chatRoomId}/kick/{memberId}")
+  public ResponseEntity<?> kickChatRoom(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable("chatRoomId") Long chatRoomId,
+      @PathVariable("memberId") Long memberId) {
+    return ResponseEntity.ok(chatRoomService.kickChatRoom(customUserDetails, chatRoomId, memberId));
+  }
+
   @GetMapping("/chatRoom/{chatRoomId}/message")
   public ResponseEntity<?> findAllMessageChatRoom(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatMessageService.java
@@ -6,5 +6,6 @@ public interface ChatMessageService {
   ChatMessageDto chatMessage(ChatMessageDto request, Long roomId);
   ChatMessageDto enterMessage(ChatMessageDto request, Long roomId);
   ChatMessageDto exitMessage(ChatMessageDto request, Long roomId);
+  ChatMessageDto kickMessage(ChatMessageDto request, Long roomId);
   void saveChatMessage(ChatMessageDto response);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatRoomService.java
@@ -20,6 +20,8 @@ public interface ChatRoomService {
 
   void exitChatRoom(CustomUserDetails customUserDetails, Long chatRoomId);
 
+  ChatRoomResponse kickChatRoom(CustomUserDetails customUserDetails, Long chatRoomId, Long memberId);
+
   Slice<ChatMessageDto> findAllMessageChatRoom(CustomUserDetails customUserDetails, ChatMessageRequest request,
       Long chatRoomId);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatMessageServiceImpl.java
@@ -65,6 +65,22 @@ public class ChatMessageServiceImpl implements ChatMessageService {
   }
 
   @Override
+  public ChatMessageDto kickMessage(ChatMessageDto request, Long roomId) {
+    ChatParticipant chatParticipant = participantRepository.findById(request.getMemberId())
+        .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+    String message = chatParticipant.getMember().getNickname() + "님이 강퇴당했습니다.";
+
+    return ChatMessageDto.builder()
+        .roomId(roomId)
+        .memberId(request.getMemberId())
+        .message(message)
+        .messageType(MessageType.KICK)
+        .sendAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Override
   public void saveChatMessage(ChatMessageDto response) {
     ChatParticipant chatParticipant = participantRepository.findByMemberIdAndChatRoomId(
             response.getMemberId(), response.getRoomId())

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -150,6 +150,22 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     return message.map(ChatMessageDto::fromEntity);
   }
 
+  @Override
+  @Transactional
+  public ChatRoomResponse kickChatRoom(CustomUserDetails customUserDetails, Long chatRoomId,
+      Long memberId) {
+    ChatParticipant chatParticipant = participantRepository.findByMemberIdAndChatRoomId(
+            memberId, chatRoomId)
+        .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+    if (participantRepository.checkRoomManager(customUserDetails.getId())) {
+      participantRepository.delete(chatParticipant);
+      chatParticipant.getChatRoom().removeChatParticipant(chatParticipant);
+    }
+
+    return ChatRoomResponse.fromEntity(chatParticipant.getChatRoom());
+  }
+
   /**
    * 채팅방 생성 유효성 검사
    */

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -37,3 +37,11 @@ GET http://localhost:8080/chatRoom/{{chatRoomId}}/message?lastMsgId=12
 Content-Type: application/x-www-form-urlencoded
 Authorization: {{accessToken}}
 
+### 채팅방 강퇴
+< {%
+  request.variables.set("chatRoomId", "13")
+  request.variables.set("memberId", "12")
+%}
+DELETE http://localhost:8080/chatRoom/{{chatRoomId}}/kick/{{memberId}}
+Content-Type: application/json
+Authorization: {{accessToken}}

--- a/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
@@ -31,6 +31,7 @@ import com.halfgallon.withcon.domain.tag.entity.Tag;
 import com.halfgallon.withcon.domain.tag.repository.TagRepository;
 import com.halfgallon.withcon.global.exception.CustomException;
 import com.halfgallon.withcon.global.exception.ErrorCode;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
@@ -297,5 +298,49 @@ class ChatRoomServiceImplTest {
 
     //then
     assertThat(messages.hasContent()).isTrue();
+  }
+
+
+  @Test
+  @DisplayName("채팅방 강퇴 성공 - 방장인 경우")
+  void kickChatRoom_Success() {
+    //given
+    List<ChatParticipant> participants = new ArrayList<>();
+    for (int i = 0; i < 9; i++) {
+      participants.add(ChatParticipant.builder()
+          .isManager(false)
+          .build());
+    }
+
+    Member user = Member.builder()
+        .id(2L)
+        .username("test1234")
+        .phoneNumber("010-1234-5678")
+        .password("12345")
+        .email("test@test.com")
+        .build();
+
+    ChatRoom chatRoom = ChatRoom.builder()
+        .id(1L)
+        .name("1번채팅방")
+        .userCount(10)
+        .chatParticipants(participants)
+        .build();
+
+
+    given(chatParticipantRepository.findByMemberIdAndChatRoomId(anyLong(), anyLong()))
+        .willReturn(Optional.of(ChatParticipant.builder()
+            .chatRoom(chatRoom)
+            .member(user)
+            .build()));
+
+    given(chatParticipantRepository.checkRoomManager(customUserDetails.getId()))
+        .willReturn(true);
+
+    //when
+    ChatRoomResponse response = chatRoomService.kickChatRoom(customUserDetails, chatRoom.getId(), user.getId());
+
+    //then
+    assertThat(response.userCount()).isEqualTo(9);
   }
 }


### PR DESCRIPTION
## 📝작업 내용
 - `@MessageMapping` 강퇴(Kick) 메시지 구현
 - 방장 `강퇴` 기능 API 구현
     - `@AuthenticationPrincipal` 을 이용하여 확인된 사용자는 채팅방의 `방장` 이라면 다른 사용자를 강퇴할 수 있습니다.

## 💬리뷰 참고사항
 - [x] API 테스트
 - [x] 테스트 코드 작성

- 현재 입장, 퇴장, 강퇴 메시지의 경우 해당 채팅방 참여자로 밸리데이션을 진행하고 있습니다.
   - 만약 `강퇴` 메시지를 보낼 때 사용자가 먼저 강퇴 당한 후에 `MessageMapping`을 진행할 경우 
   해당 밸리데이션이 `null`로 반환되기 때문에 시퀀스를 확인해서 `메시지`와  `동작` 중에 
   어느 것을  우선시해야할지 확인해봐야합니다.

## #️⃣연관된 이슈

close #55 
