### PR TITLE
[refactor] Auth와 Member 단순 수정

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/LoginFailureHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/LoginFailureHandler.java
@@ -6,7 +6,6 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.halfgallon.withcon.global.exception.ErrorCode;
 import com.halfgallon.withcon.global.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,7 +28,7 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
 
     //test
     ErrorResponse errorResponse = new ErrorResponse(BAD_REQUEST.value(),
-        ErrorCode.LOGIN_FAILURE_MESSAGE, LOGIN_FAILURE_MESSAGE.getDescription());
+        LOGIN_FAILURE_MESSAGE, LOGIN_FAILURE_MESSAGE.getDescription());
 
     response.setContentType(APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(UTF_8.name());

--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/LoginSuccessHandler.java
@@ -49,6 +49,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     // 리프래시 토큰 쿠키 생성
     Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+    refreshTokenCookie.setPath("/");
     refreshTokenCookie.setHttpOnly(true);
     refreshTokenCookie.setSecure(true);
     refreshTokenCookie.setMaxAge(REFRESH_TOKEN_COOKIE_EXPIRY);

--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/handler/OAuth2LoginFailureHandler.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.auth.security.handler;
 
+import static com.halfgallon.withcon.global.exception.ErrorCode.OAUTH2_LOGIN_FAILURE_MESSAGE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -20,7 +21,6 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
   private final ObjectMapper objectMapper;
-  private static final String OAUTH2_LOGIN_FAILURE_MESSAGE = "소셜 로그인에 실패했습니다.";
 
   @Override
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -28,7 +28,8 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
     log.info("소셜 로그인 실패");
 
     ErrorResponse errorResponse = new ErrorResponse(BAD_REQUEST.value(),
-        OAUTH2_LOGIN_FAILURE_MESSAGE);
+        OAUTH2_LOGIN_FAILURE_MESSAGE,
+        OAUTH2_LOGIN_FAILURE_MESSAGE.getDescription());
 
     response.setContentType(APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(UTF_8.name());

--- a/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
@@ -27,7 +27,7 @@ public class Member extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, unique = true)
   private String username;
 
   @Column

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
   METHOD_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Method 요청입니다."),
   CONTENT_TYPE_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Content-type 요청입니다."),
   LOGIN_FAILURE_MESSAGE(BAD_REQUEST.value(), "아이디 혹은 비밀번호가 올바르지 않습니다."),
+  OAUTH2_LOGIN_FAILURE_MESSAGE(BAD_REQUEST.value(), "소셜 로그인에 실패하셨습니다."),
 
   /**
    * 401 Unauthorized

--- a/src/test/http/auth.http
+++ b/src/test/http/auth.http
@@ -5,9 +5,8 @@ Content-Type: application/json
 {
   "username": "abcd7787",
   "password": "1q2w3e4r!",
-  "email": "wtit0822@test.com",
   "nickname": "위콘2",
-  "phoneNumber": "010-7774-4567"
+  "phoneNumber": "01077744567"
 }
 
 ### 로그인


### PR DESCRIPTION
## 📝작업 내용
Member 엔티티의 username 을 unique = true 로 변경하였습니다.
소셜 로그인 시 구현했던 실패 핸들러에서 ErrorResponse를 생성할 때 파라미터 값을 잘못 넘겨줬었습니다. 해당 내용을 수정하였습니다.

+ refresh_token 이라는 이름을 가진 쿠키가 아래와 같이 두 개가 생성되었습니다.(일반로그인, 소셜로그인 시 path가 달라서 생긴 이슈)

![스크린샷 2024-02-07 17 03 15](https://github.com/HalfGallonTeam/WithCon_BE/assets/68311264/052f3cb3-3017-47a6-ac05-6697b7e6e31e)

```java
Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
refreshTokenCookie.setPath("/"); // Path를 설정해줌으로서 해결하였습니다.
```

## 💬리뷰 참고사항

쿠키 이슈 같은 경우는 사실 일반 로그인을 하고나서, 로그아웃을 거치지 않고 소셜 로그인을 할 수 있는 경우는 없을 것 같다고 생각됩니다.
로그아웃을 하면 쿠키는 삭제되서 중복될 우려도 없을 것 같습니다.
그래도 조금 더 안전하게 사용하기 위해 수정하였습니다.

## #️⃣연관된 이슈
(close) #21 
