### PR TITLE
[feat] 공연 CRUD 기능 구현 및 공연 세부 정보, 공연 찜 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ out/
 
 ### querydsl ###
 /src/main/generated
+src/main/resources/application-local.yml
+src/main/resources/application-local.yml

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.chat.entity;
 
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
 import com.halfgallon.withcon.domain.tag.entity.Tag;
 import com.halfgallon.withcon.global.entity.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
@@ -8,6 +9,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +43,10 @@ public class ChatRoom extends BaseTimeEntity {
   @Builder.Default
   @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
   List<Tag> tags = new ArrayList<>();
+
+  @ManyToOne
+  @JoinColumn(name = "performance_id")
+  Performance performance;
 
   public void updateUserCount() {
     this.userCount = this.chatParticipants.size();

--- a/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.halfgallon.withcon.domain.member.entity;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.halfgallon.withcon.domain.member.constant.LoginType;
+import com.halfgallon.withcon.domain.performance.entitiy.PerformanceLike;
 import com.halfgallon.withcon.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,6 +12,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,4 +49,6 @@ public class Member extends BaseTimeEntity {
   @Column(nullable = false)
   private String phoneNumber;
 
+  @OneToMany
+  private List<PerformanceLike> likes;
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/constant/Status.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/constant/Status.java
@@ -1,0 +1,9 @@
+package com.halfgallon.withcon.domain.performance.constant;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Status {
+  RUNNING,
+  END;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceController.java
@@ -1,0 +1,43 @@
+package com.halfgallon.withcon.domain.performance.controller;
+
+import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
+import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+import com.halfgallon.withcon.domain.performance.service.PerformanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/performance")
+public class PerformanceController {
+
+  private final PerformanceService performanceService;
+
+  @PostMapping
+  public ResponseEntity<PerformanceResponse> createPerformance(@RequestBody PerformanceRequest request) {
+    return ResponseEntity.ok(performanceService.createPerformance(request));
+  }
+
+  @GetMapping("/{performanceId}")
+  public ResponseEntity<PerformanceResponse> findPerformance(@PathVariable String performanceId) {
+    return ResponseEntity.ok(performanceService.findPerformance(performanceId));
+  }
+
+  @PutMapping
+  public ResponseEntity<PerformanceResponse> updatePerformance(@RequestBody PerformanceRequest request) {
+    return ResponseEntity.ok(performanceService.updatePerformance(request));
+  }
+
+  @DeleteMapping("/{performanceId}")
+  public ResponseEntity<PerformanceResponse> deletePerformance(@PathVariable String performanceId) {
+    return ResponseEntity.ok(performanceService.deletePerformance(performanceId));
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/request/PerformanceRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/request/PerformanceRequest.java
@@ -1,0 +1,42 @@
+package com.halfgallon.withcon.domain.performance.dto.request;
+
+import com.halfgallon.withcon.domain.performance.constant.Status;
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PerformanceRequest {
+
+  private String id;
+
+  private String name;
+
+  private String startDate;
+
+  private String endDate;
+
+  private String poster;
+
+  private String facility;
+
+  private Status status;
+
+  private Long likes;
+
+  public Performance toEntity() {
+    return Performance.builder()
+        .id(id)
+        .name(name)
+        .startDate(startDate)
+        .endDate(endDate)
+        .poster(poster)
+        .facility(facility)
+        .status(status)
+        .likes(likes)
+        .build();
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/request/PerformanceRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/request/PerformanceRequest.java
@@ -3,6 +3,7 @@ package com.halfgallon.withcon.domain.performance.dto.request;
 import com.halfgallon.withcon.domain.performance.constant.Status;
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,9 +16,9 @@ public class PerformanceRequest {
 
   private String name;
 
-  private String startDate;
+  private LocalDate startDate;
 
-  private String endDate;
+  private LocalDate endDate;
 
   private String poster;
 

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
@@ -1,0 +1,42 @@
+package com.halfgallon.withcon.domain.performance.dto.response;
+
+import com.halfgallon.withcon.domain.performance.constant.Status;
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PerformanceResponse {
+
+  private String id;
+
+  private String name;
+
+  private String startDate;
+
+  private String endDate;
+
+  private String poster;
+
+  private String facility;
+
+  private Status status;
+
+  private Long likes;
+
+  public static PerformanceResponse fromEntity(Performance performance) {
+    return PerformanceResponse.builder()
+        .id(performance.getId())
+        .name(performance.getName())
+        .startDate(performance.getStartDate())
+        .endDate(performance.getEndDate())
+        .poster(performance.getPoster())
+        .facility(performance.getFacility())
+        .status(performance.getStatus())
+        .likes(performance.getLikes())
+        .build();
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
@@ -3,6 +3,7 @@ package com.halfgallon.withcon.domain.performance.dto.response;
 import com.halfgallon.withcon.domain.performance.constant.Status;
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,9 +16,9 @@ public class PerformanceResponse {
 
   private String name;
 
-  private String startDate;
+  private LocalDate startDate;
 
-  private String endDate;
+  private LocalDate endDate;
 
   private String poster;
 

--- a/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/Performance.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/Performance.java
@@ -1,0 +1,73 @@
+package com.halfgallon.withcon.domain.performance.entitiy;
+
+import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import com.halfgallon.withcon.domain.performance.constant.Status;
+import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
+import com.halfgallon.withcon.global.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Performance extends BaseTimeEntity {
+
+  @Id
+  private String id;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private String startDate;
+
+  @Column(nullable = false)
+  private String endDate;
+
+  @Column(nullable = false)
+  private String poster;
+
+  @Column(nullable = false)
+  private String facility;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private Status status;
+
+  @Column(nullable = false) 
+  private Long likes;
+
+  @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<ChatRoom> chatRoom;
+
+  @OneToMany(mappedBy = "performance")
+  private List<PerformanceLike> performanceLikes;
+
+  @OneToOne(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+  private PerformanceDetail performanceDetail;
+
+  public void update(PerformanceRequest request) {
+    this.id = request.getId();
+    this.name = request.getName();
+    this.startDate = request.getStartDate();
+    this.endDate = request.getEndDate();
+    this.poster = request.getPoster();
+    this.facility = request.getFacility();
+    this.status = request.getStatus();
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/Performance.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/Performance.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
@@ -34,10 +35,10 @@ public class Performance extends BaseTimeEntity {
   private String name;
 
   @Column(nullable = false)
-  private String startDate;
+  private LocalDate startDate;
 
   @Column(nullable = false)
-  private String endDate;
+  private LocalDate endDate;
 
   @Column(nullable = false)
   private String poster;

--- a/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/PerformanceDetail.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/PerformanceDetail.java
@@ -1,0 +1,45 @@
+package com.halfgallon.withcon.domain.performance.entitiy;
+
+import com.halfgallon.withcon.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class PerformanceDetail extends BaseTimeEntity {
+
+  @Id
+  private String id;
+
+  @Column(nullable = false)
+  private Long price;
+
+  @Column(nullable = false)
+  private String actors;
+
+  @Column(nullable = false)
+  private String company;
+
+  @Column(nullable = false)
+  private String run_time;
+
+  @Column(nullable = false)
+  private String genre;
+
+  @Column(nullable = false)
+  private String sty;
+
+  @Column(nullable = false)
+  private String time;
+
+  @Column(nullable = false)
+  private String age;
+
+  @OneToOne
+  @MapsId
+  @JoinColumn(name = "id")
+  private Performance performance;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/PerformanceLike.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/PerformanceLike.java
@@ -1,0 +1,24 @@
+package com.halfgallon.withcon.domain.performance.entitiy;
+
+import com.halfgallon.withcon.domain.member.entity.Member;
+import com.halfgallon.withcon.global.entity.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class PerformanceLike extends BaseTimeEntity {
+
+  @Id
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member Member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "performance_id")
+  private Performance performance;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceDetailRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceDetailRepository.java
@@ -1,0 +1,10 @@
+package com.halfgallon.withcon.domain.performance.repository;
+
+import com.halfgallon.withcon.domain.performance.entitiy.PerformanceDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PerformanceDetailRepository extends JpaRepository<PerformanceDetail, String> {
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceLikeRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceLikeRepository.java
@@ -1,0 +1,10 @@
+package com.halfgallon.withcon.domain.performance.repository;
+
+import com.halfgallon.withcon.domain.performance.entitiy.PerformanceLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PerformanceLikeRepository extends JpaRepository<PerformanceLike, Long> {
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceRepository.java
@@ -1,0 +1,10 @@
+package com.halfgallon.withcon.domain.performance.repository;
+
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PerformanceRepository extends JpaRepository<Performance, String> {
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceService.java
@@ -1,0 +1,12 @@
+package com.halfgallon.withcon.domain.performance.service;
+
+import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
+import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+
+public interface PerformanceService {
+
+  PerformanceResponse createPerformance(PerformanceRequest request);
+  PerformanceResponse findPerformance(String performanceId);
+  PerformanceResponse updatePerformance(PerformanceRequest request);
+  PerformanceResponse deletePerformance(String performanceId);
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImpl.java
@@ -1,0 +1,54 @@
+package com.halfgallon.withcon.domain.performance.service.impl;
+
+import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
+import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import com.halfgallon.withcon.domain.performance.repository.PerformanceRepository;
+import com.halfgallon.withcon.domain.performance.service.PerformanceService;
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceServiceImpl implements PerformanceService {
+
+  private final PerformanceRepository performanceRepository;
+
+  @Override
+  @Transactional
+  public PerformanceResponse createPerformance(PerformanceRequest request) {
+    return PerformanceResponse.fromEntity(performanceRepository.save(request.toEntity()));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public PerformanceResponse findPerformance(String performanceId) {
+    return PerformanceResponse.fromEntity(
+        performanceRepository.findById(performanceId).orElseThrow(() -> new CustomException(
+            ErrorCode.PERFORMANCE_NOT_FOUND)));
+  }
+
+  @Override
+  @Transactional
+  public PerformanceResponse updatePerformance(PerformanceRequest request) {
+    Performance performance = performanceRepository.findById(request.getId())
+        .orElseThrow(() -> new CustomException(ErrorCode.PERFORMANCE_NOT_FOUND));
+
+    performance.update(request);
+    return PerformanceResponse.fromEntity(performanceRepository.save(performance));
+  }
+
+  @Override
+  @Transactional
+  public PerformanceResponse deletePerformance(String performanceId) {
+    Performance performance = performanceRepository.findById(performanceId)
+        .orElseThrow(() -> new CustomException(ErrorCode.PERFORMANCE_NOT_FOUND));
+
+    performanceRepository.deleteById(performanceId);
+
+    return PerformanceResponse.fromEntity(performance);
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(NOT_FOUND.value(), "존재하지 않는 회원입니다."),
   CHATROOM_NOT_FOUND(NOT_FOUND.value(), "채팅방이 생성되지 않았습니다."),
   PARTICIPANT_NOT_FOUND(NOT_FOUND.value(), "해당 채팅방 참여자가 아닙니다."),
+  PERFORMANCE_NOT_FOUND(NOT_FOUND.value(), "존재하지 않는 공연입니다."),
 
   /**
    * 409 conflict

--- a/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImplTest.java
@@ -43,7 +43,6 @@ class ChatParticipantServiceImplTest {
         .username("test1234")
         .phoneNumber("010-1234-5678")
         .password("12345")
-        .email("test@test.com")
         .build();
 
     customUserDetails = CustomUserDetails.fromEntity(member);

--- a/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
@@ -68,7 +68,6 @@ class ChatRoomServiceImplTest {
         .username("test1234")
         .phoneNumber("010-1234-5678")
         .password("12345")
-        .email("test@test.com")
         .build();
 
     customUserDetails = CustomUserDetails.fromEntity(member);

--- a/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
@@ -16,6 +16,7 @@ import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
 import com.halfgallon.withcon.domain.performance.service.impl.PerformanceServiceImpl;
 import com.halfgallon.withcon.global.annotation.WithCustomMockUser;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -109,8 +110,8 @@ class PerformanceControllerTest {
     return PerformanceRequest.builder()
         .id("id")
         .name("name")
-        .startDate("2024-02-18")
-        .endDate("2024-02-20")
+        .startDate(LocalDate.ofEpochDay(2024-02-18))
+        .endDate(LocalDate.ofEpochDay(2024-02-20))
         .poster("asdfler")
         .facility("공연 장소")
         .status(Status.RUNNING)
@@ -122,8 +123,8 @@ class PerformanceControllerTest {
     return PerformanceResponse.builder()
         .id("id")
         .name("name")
-        .startDate("2024-02-18")
-        .endDate("2024-02-20")
+        .startDate(LocalDate.ofEpochDay(2024-02-18))
+        .endDate(LocalDate.ofEpochDay(2024-02-20))
         .poster("asdfler")
         .facility("공연 장소")
         .status(Status.RUNNING)

--- a/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
@@ -1,0 +1,134 @@
+package com.halfgallon.withcon.domain.performance.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halfgallon.withcon.domain.chat.dto.ChatRoomResponse;
+import com.halfgallon.withcon.domain.performance.constant.Status;
+import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
+import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+import com.halfgallon.withcon.domain.performance.service.impl.PerformanceServiceImpl;
+import com.halfgallon.withcon.global.annotation.WithCustomMockUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest(PerformanceController.class)
+class PerformanceControllerTest {
+
+  @MockBean
+  PerformanceServiceImpl performanceService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Autowired
+  WebApplicationContext webApplicationContext;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders
+        .webAppContextSetup(webApplicationContext)
+        .build();
+  }
+
+  @Test
+  @WithCustomMockUser
+  @DisplayName("공연 생성 완료")
+  void createPerformance_Success() throws Exception{
+
+    given(performanceService.createPerformance(getPerformanceRequest())).willReturn(getPerformanceResponse());
+
+
+    mockMvc.perform(post("/performance")
+
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(getPerformanceRequest())))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("공연 조회 완료")
+  void findPerformance_Success() throws Exception {
+    String id = "id";
+
+    given(performanceService.createPerformance(getPerformanceRequest())).willReturn(getPerformanceResponse());
+
+
+    mockMvc.perform(get("/performance/" + id)
+          .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isOk())
+          .andDo(print());
+  }
+
+  @Test
+  @DisplayName("공연 수정 완료")
+  void updatePerformance_Success() throws Exception {
+
+    given(performanceService.createPerformance(getPerformanceRequest())).willReturn(getPerformanceResponse());
+
+    mockMvc.perform(put("/performance")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(getPerformanceRequest())))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("공연 삭제 완료")
+  void deletePerformance_Success() throws Exception {
+    String id = "id";
+
+    given(performanceService.createPerformance(getPerformanceRequest())).willReturn(getPerformanceResponse());
+
+    mockMvc.perform(delete("/performance/" + id)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  private static PerformanceRequest getPerformanceRequest() {
+    return PerformanceRequest.builder()
+        .id("id")
+        .name("name")
+        .startDate("2024-02-18")
+        .endDate("2024-02-20")
+        .poster("asdfler")
+        .facility("공연 장소")
+        .status(Status.RUNNING)
+        .likes(4000L)
+        .build();
+  }
+
+  private static PerformanceResponse getPerformanceResponse() {
+    return PerformanceResponse.builder()
+        .id("id")
+        .name("name")
+        .startDate("2024-02-18")
+        .endDate("2024-02-20")
+        .poster("asdfler")
+        .facility("공연 장소")
+        .status(Status.RUNNING)
+        .likes(4000L)
+        .build();
+  }
+
+}

--- a/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImplTest.java
@@ -16,6 +16,7 @@ import com.halfgallon.withcon.domain.performance.entitiy.Performance;
 import com.halfgallon.withcon.domain.performance.repository.PerformanceRepository;
 import com.halfgallon.withcon.global.exception.CustomException;
 import com.halfgallon.withcon.global.exception.ErrorCode;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -131,8 +132,8 @@ class PerformanceServiceImplTest {
     return PerformanceRequest.builder()
         .id("id")
         .name("name")
-        .startDate("2024-02-18")
-        .endDate("2024-02-20")
+        .startDate(LocalDate.ofEpochDay(2024-02-18))
+        .endDate(LocalDate.ofEpochDay(2024-02-20))
         .poster("asdfler")
         .facility("공연 장소")
         .status(Status.RUNNING)
@@ -144,8 +145,8 @@ class PerformanceServiceImplTest {
     return PerformanceResponse.builder()
         .id("id")
         .name("name")
-        .startDate("2024-02-18")
-        .endDate("2024-02-20")
+        .startDate(LocalDate.ofEpochDay(2024-02-18))
+        .endDate(LocalDate.ofEpochDay(2024-02-20))
         .poster("asdfler")
         .facility("공연 장소")
         .status(Status.RUNNING)

--- a/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImplTest.java
@@ -1,0 +1,155 @@
+package com.halfgallon.withcon.domain.performance.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.halfgallon.withcon.domain.performance.constant.Status;
+import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
+import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import com.halfgallon.withcon.domain.performance.repository.PerformanceRepository;
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.exception.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PerformanceServiceImplTest {
+
+  @InjectMocks
+  PerformanceServiceImpl performanceService;
+
+  @Mock
+  PerformanceRepository performanceRepository;
+
+  @Test
+  @DisplayName("공연 생성 완료")
+  void createPerformance_Success() {
+    // given
+    PerformanceRequest request = getPerformanceRequest();
+    Performance performance = request.toEntity();
+    PerformanceResponse expectedResponse = getPerformanceResponse();
+
+    given(performanceRepository.save(any(Performance.class))).willReturn(performance);
+
+    // when
+    PerformanceResponse actualResponse = performanceService.createPerformance(request);
+
+    // then
+    assertThat(expectedResponse.getName()).isEqualTo(actualResponse.getName());
+  }
+
+  @Test
+  @DisplayName("공연 조회 완료")
+  void findPerformance_Success() {
+    // given
+    PerformanceRequest request = getPerformanceRequest();
+    Performance performance = request.toEntity();
+    PerformanceResponse expectedResponse = getPerformanceResponse();
+    String id = "id";
+
+    given(performanceRepository.findById(anyString())).willReturn(
+        Optional.ofNullable(performance));
+
+    // when
+    PerformanceResponse actualResponse = performanceService.findPerformance(id);
+
+    // then
+    assertThat(expectedResponse.getName()).isEqualTo(actualResponse.getName());
+  }
+
+  @Test
+  @DisplayName("공연 조회 실패 - 공연이 존재하지 않습니다.")
+  void findPerformance_failed() {
+    PerformanceRequest request = getPerformanceRequest();
+    Performance performance = request.toEntity();
+    PerformanceResponse expectedResponse = getPerformanceResponse();
+    String id = "id";
+
+    given(performanceRepository.findById(anyString())).willReturn(Optional.empty());
+
+    // when
+    CustomException customException = Assertions.assertThrows(CustomException.class,
+        () -> performanceService.findPerformance(id));
+
+    // then
+    assertThat(ErrorCode.PERFORMANCE_NOT_FOUND.getDescription()).isEqualTo(customException.getMessage());
+  }
+
+  @Test
+  @DisplayName("공연 수정 완료")
+  void updatePerformance_Success() {
+    // given
+    PerformanceRequest request = getPerformanceRequest();
+    Performance performance = request.toEntity();
+    PerformanceResponse expectedResponse = getPerformanceResponse();
+
+    given(performanceRepository.findById(anyString())).willReturn(Optional.of(performance));
+    given(performanceRepository.save(any(Performance.class))).willReturn(performance);
+
+    // when
+    PerformanceResponse actualResponse = performanceService.updatePerformance(request);
+
+    // then
+    assertThat(expectedResponse.getName()).isEqualTo(actualResponse.getName());
+
+  }
+
+  @Test
+  @DisplayName("공연 삭제 완료")
+  void deletePerformance_Success() {
+    // given
+    PerformanceRequest request = getPerformanceRequest();
+    Performance performance = request.toEntity();
+    PerformanceResponse expectedResponse = getPerformanceResponse();
+    String id = "id";
+
+    given(performanceRepository.findById(any(String.class))).willReturn(
+        Optional.ofNullable(performance));
+
+    // when
+    PerformanceResponse actualResponse = performanceService.deletePerformance(id);
+
+    // then
+    assertThat(expectedResponse.getName()).isEqualTo(actualResponse.getName());
+    verify(performanceRepository, times(1)).deleteById(id);
+  }
+
+  private static PerformanceRequest getPerformanceRequest() {
+    return PerformanceRequest.builder()
+        .id("id")
+        .name("name")
+        .startDate("2024-02-18")
+        .endDate("2024-02-20")
+        .poster("asdfler")
+        .facility("공연 장소")
+        .status(Status.RUNNING)
+        .likes(4000L)
+        .build();
+  }
+
+  private static PerformanceResponse getPerformanceResponse() {
+    return PerformanceResponse.builder()
+        .id("id")
+        .name("name")
+        .startDate("2024-02-18")
+        .endDate("2024-02-20")
+        .poster("asdfler")
+        .facility("공연 장소")
+        .status(Status.RUNNING)
+        .likes(4000L)
+        .build();
+  }
+}


### PR DESCRIPTION
## 📝작업 내용

- 공연 생성
- 공연 조회
- 공연 수정
- 공연 삭제

- 공연 세부 정보, 공연 찜 entity, repositroy 생성

## 💬리뷰 참고사항

- 기본적인 CRUD만 구현해놓았기에 부족한 기능들은 차후 추가
- Performance와 PerformanceDetail가 동일한 Id를 사용하는 방식
- startDate와 endDate의 타입에 대해 고민

## #️⃣연관된 이슈

(close) #54 
