### PR TITLE
[feat] 채팅방 공연 서비스 추가 및 ddl 파일 생성

### DIFF
--- a/sql/performance.sql
+++ b/sql/performance.sql
@@ -1,0 +1,45 @@
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('1', LOCALTIME, LOCALTIME, '2024-02-24', '달밤엔시어터', 0, '안녕달아', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF234853_240202_100411.gif', '2024-02-09', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('2', LOCALTIME, LOCALTIME, '2024-02-11', '소극장 혜화당(구. 까망소극장)', 0, '날이면 날마다 낭독해', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF234735_240131_102237.jpg', '2024-02-09', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('3', LOCALTIME, LOCALTIME, '2024-03-31', '아트하우스', 0, '거꾸로 청개구리', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF234570_240129_095812.png', '2024-02-03', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('4', LOCALTIME, LOCALTIME, '2024-03-03', '예술의전당 [서울] 자유소극장', 0, '이상한 나라의 아빠', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF233138_231228_093133.gif', '2024-01-28', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('5', LOCALTIME, LOCALTIME, '2024-02-25', '상상나라극장', 0, '넌 특별하단다', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF232994_231222_125048.gif', '2024-01-20', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('6', LOCALTIME, LOCALTIME, '2024-03-24', '세종문화회관 세종대극장', 0, '노트르담 드 파리', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF230511_231122_093753.png', '2024-01-24', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('7', LOCALTIME, LOCALTIME, '2024-02-25', '한전아트센터', 0, '겨울나그네', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF230087_231116_100306.gif', '2023-12-15', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('8', LOCALTIME, LOCALTIME, '2024-03-10', '드림시어터 [대학로]', 0, '창작단막극축제: 뿔난이들', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF230087_231116_100306.gif', '2024-02-06', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('9', LOCALTIME, LOCALTIME, '2024-02-24', '하땅세극장', 0, '고래바위에서 기다려', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF233723_240111_093113.gif', '2024-01-20', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('10', LOCALTIME, LOCALTIME, '2024-02-18', '벨로주 [홍대] (구. 왓에버)', 0, '구원찬 단독공연, HOMESICK', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF233882_240115_105255.gif', '2024-02-09', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('11', LOCALTIME, LOCALTIME, '2024-02-18', '이화여고 100주년 기념관', 0, 'HYNN(박혜원) 첫 소극장 콘서트, The Cabin', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF233882_240115_105255.gif', '2024-02-02', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('12', LOCALTIME, LOCALTIME, '2024-02-24', '파닥파닥클럽', 0, '금토재즈클럽 (2월), The Cabin', 'https://www.kopis.or.kr/upload/pfmPoster/PF_PF234350_240123_104211.png', '2024-02-02', 'RUNNING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('13', LOCALTIME, LOCALTIME, '2024-02-25', 'SK올림픽핸드볼경기장', 0, '2024 10CM ENCORE CONCERT ‘=10’', 'https://ticketimage.interpark.com/Play/image/large/24/24001528_p.gif', '2024-02-24', 'WAITING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('14', LOCALTIME, LOCALTIME, '2024-02-18', '올림픽공원 올림픽홀', 0, '2024 로꼬 콘서트 ‘ALL I NEED’', 'https://ticketimage.interpark.com/Play/image/large/23/23018690_p.gif', '2024-02-17', 'WAITING');
+
+INSERT INTO performance (id, created_at, modified_at, end_date, facility, likes, name, poster, start_date, status)
+VALUES ('15', LOCALTIME, LOCALTIME, '2024-02-17', '블루스퀘어 마스터카드홀', 0, 'LEE YOUNGJI 1st ASIA TOUR ‘THE MAIN CHARACTER’ in SEOUL', 'https://ticketimage.interpark.com/Play/image/large/24/24000313_p.gif', '2024-02-18', 'WAITING');
+

--- a/sql/performanceDetail.sql
+++ b/sql/performanceDetail.sql
@@ -1,0 +1,44 @@
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('1', LOCALTIME, LOCALTIME, '정맑음, 박슬아, 김성환, 김주은', '36개월 이상', '달밤엔컴퍼니', 'MUSICAL', 40000, '60분', '토요일 ~ 일요일(14:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('2', LOCALTIME, LOCALTIME, '이채연, 김재홍, 변상일, 이치호 등', '만 13세 이상', '소극장 혜화당', 'THEATER', 15000, '90분', '공휴일(15:00,17:00,18:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('3', LOCALTIME, LOCALTIME, '해당정보 없음', '24개월 이상', '두부기획', 'THEATER', 25000, '50분', '토요일 ~ 일요일(11:00,12:30)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('4', LOCALTIME, LOCALTIME, '성기윤, 정의욱, 김가은, 이휴 등', '만 7세 이상', '(주)다아트', 'THEATER', 66000, '110분', '토요일 ~ 일요일(14:00,18:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('5', LOCALTIME, LOCALTIME, '해당정보 없음', '만 7세 이상', '(사)하늘에', 'MUSICAL', 35000, '50분', '토요일 ~ 일요일(11:00,14:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('6', LOCALTIME, LOCALTIME, '정성화, 양준모, 윤형렬, 유리아 등', '만 7세 이상', '(주)마스트엔터테인먼트', 'MUSICAL', 110000, '150분', '화, 목, 금 19시30분');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('7', LOCALTIME, LOCALTIME, '이창섭, 한재아, 임예진, 민선예 등', '만 13세 이상', '(주)에이콤', 'MUSICAL', 130000, '150분', '화요일 ~ 금요일(19:30)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('8', LOCALTIME, LOCALTIME, '주수자, 전기광, 김윤찬 등', '만 15세 이상', '드림시어터 소극장', 'THEATER', 20000, '70분', '화, 수, 목 7시 30분');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('9', LOCALTIME, LOCALTIME, '이지연, 김예린, 황호찬, 백상민, 정지혜', '36개월 이상', '햇살놀이터', 'THEATER', 30000, '60분', '토요일 14:00');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('10', LOCALTIME, LOCALTIME, '구원찬', '전체관람가', '마운드미디어(주최)', 'CONCERT', 66000, '80분', '금요일 ~ 일요일(17:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('11', LOCALTIME, LOCALTIME, '박혜원', '만 7세 이상', '(주)인터파크트리플', 'CONCERT', 121000, '100분', '금요일(20:00), 토요일(18:00), 일요일(17:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('12', LOCALTIME, LOCALTIME, '김동현, 이종원, 박성은, 김순영 등', '전체 관람가', '파닥파닥클럽', 'CONCERT', 15000, '100분', '금요일 ~ 토요일(20:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('13', LOCALTIME, LOCALTIME, '10cm', '만 8세이상', '(주)마운트미디어', 'CONCERT', 132000, '120분', '토요일(18:00), 일요일(17:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('14', LOCALTIME, LOCALTIME, '로꼬', '미취학아동입장불가', '(주)에이오엠지', 'CONCERT', 132000, '120분', '토요일(19:00), 일요일(18:00)');
+
+INSERT INTO performance_detail (id, created_at, modified_at, actors, age, company, genre, price, run_time, time)
+VALUES ('15', LOCALTIME, LOCALTIME, '이영지', '만 7세이상', '(주)메인스트림윈터', 'CONCERT', 118000, '120분', '토요일(18:00), 일요일(18:00)');

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
@@ -4,12 +4,13 @@ import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
 import java.util.List;
 
 public record ChatRoomRequest(
-    String name,
+    String roomName,
+    Long performanceId,
     List<String> tags
 ) {
   public ChatRoom toEntity() {
     return ChatRoom.builder()
-        .name(this.name)
+        .name(this.roomName)
         .build();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomResponse.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 public record ChatRoomResponse(
     Long chatRoomId,
     String roomName,
+    Long performanceId,
     Integer userCount,
     List<String> tags,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -21,6 +22,7 @@ public record ChatRoomResponse(
     return ChatRoomResponse.builder()
         .chatRoomId(chatRoom.getId())
         .roomName(chatRoom.getName())
+        .performanceId(Long.valueOf(chatRoom.getPerformance().getId()))
         .userCount(chatRoom.getUserCount())
         .tags(chatRoom.getTags().stream().map(Tag::getName).toList())
         .createdAt(chatRoom.getCreatedAt())

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
@@ -6,6 +6,7 @@ import com.halfgallon.withcon.global.entity.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -44,9 +45,9 @@ public class ChatRoom extends BaseTimeEntity {
   @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
   List<Tag> tags = new ArrayList<>();
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "performance_id")
-  Performance performance;
+  private Performance performance;
 
   public void updateUserCount() {
     this.userCount = this.chatParticipants.size();
@@ -64,5 +65,9 @@ public class ChatRoom extends BaseTimeEntity {
 
   public void addTag(Tag tag) {
     this.tags.add(tag);
+  }
+
+  public void updatePerformance(Performance performance) {
+    this.performance = performance;
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/constant/Genre.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/constant/Genre.java
@@ -1,0 +1,14 @@
+package com.halfgallon.withcon.domain.performance.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Genre {
+  MUSICAL("뮤지컬"),
+  CONCERT("콘서트"),
+  THEATER("연극");
+
+  private final String description;
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/constant/Status.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/constant/Status.java
@@ -1,9 +1,7 @@
 package com.halfgallon.withcon.domain.performance.constant;
 
-import lombok.AllArgsConstructor;
-
-@AllArgsConstructor
 public enum Status {
+  WAITING,
   RUNNING,
-  END;
+  END
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/PerformanceDetail.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/PerformanceDetail.java
@@ -1,14 +1,19 @@
 package com.halfgallon.withcon.domain.performance.entitiy;
 
+import com.halfgallon.withcon.domain.performance.constant.Genre;
 import com.halfgallon.withcon.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class PerformanceDetail extends BaseTimeEntity {
 
   @Id
@@ -27,10 +32,8 @@ public class PerformanceDetail extends BaseTimeEntity {
   private String run_time;
 
   @Column(nullable = false)
-  private String genre;
-
-  @Column(nullable = false)
-  private String sty;
+  @Enumerated(EnumType.STRING)
+  private Genre genre;
 
   @Column(nullable = false)
   private String time;

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -4,9 +4,10 @@ Content-Type: application/json
 Authorization: {{accessToken}}
 
 {
-  "memberId": 13,
-  "name": "13번채팅방",
-  "tags": ["#13번", "#19번", "위드"]
+  "memberId": 2,
+  "roomName": "채팅방2",
+  "performanceId": 1,
+  "tags": ["#123", "#서울", "위드"]
 }
 
 ### 채팅방 조회


### PR DESCRIPTION
## 📝작업 내용
1. 채팅방 서비스 공연 정보 추가
    - `request` 및 `response` 시에 공연 ID 정보 추가
    - 채팅방 생성 시에 공연 정보 확인해서 채팅방 엔티티에 정보 업데이트 진행

2. 공연 정보 ddl 파일 생성
    - performance, performance_detail ddl 파일 생성 (`local` 환경에 DB 내용 추가해서 테스트로 사용)

3. 공연 정보 constant 파일 리팩토링
   1. 공연 상태(`status`)에 waiting(대기) 상태 추가
   2. `PerformanceDetail` 엔티티 변수 타입 변경 및 삭제
       - 줄거리(sty) 삭제(해당 내용은 추가할 적당한 내용이 없어서 삭제 진행)
       - Genre 상수 타입 클래스 생성(string -> Genre)

## 💬리뷰 참고사항

- [x] API 테스트

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/bc39904f-b3cf-40a9-8143-b5ab5ada5da1)

## #️⃣연관된 이슈

close #71 #72 
