### PR TITLE
[feat] 공연 검색 기능 구현

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceController.java
@@ -3,8 +3,10 @@ package com.halfgallon.withcon.domain.performance.controller;
 import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
 import com.halfgallon.withcon.domain.performance.service.PerformanceService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,7 +46,8 @@ public class PerformanceController {
   }
 
   @GetMapping
-  public ResponseEntity<List<PerformanceResponse>> searchPerformance(@RequestParam String keyword) {
-    return ResponseEntity.ok(performanceService.searchPerformance(keyword));
+  public ResponseEntity<Page<PerformanceResponse>> searchPerformance(@RequestParam String keyword, @PageableDefault(size = 10)
+      Pageable pageable) {
+    return ResponseEntity.ok(performanceService.searchPerformance(keyword, pageable));
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceController.java
@@ -3,6 +3,7 @@ package com.halfgallon.withcon.domain.performance.controller;
 import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
 import com.halfgallon.withcon.domain.performance.service.PerformanceService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,5 +41,10 @@ public class PerformanceController {
   @DeleteMapping("/{performanceId}")
   public ResponseEntity<PerformanceResponse> deletePerformance(@PathVariable String performanceId) {
     return ResponseEntity.ok(performanceService.deletePerformance(performanceId));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<PerformanceResponse>> searchPerformance(@RequestParam String keyword) {
+    return ResponseEntity.ok(performanceService.searchPerformance(keyword));
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/request/PerformanceRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/request/PerformanceRequest.java
@@ -2,9 +2,7 @@ package com.halfgallon.withcon.domain.performance.dto.request;
 
 import com.halfgallon.withcon.domain.performance.constant.Status;
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
-import jakarta.persistence.Id;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -26,8 +24,6 @@ public class PerformanceRequest {
 
   private Status status;
 
-  private Long likes;
-
   public Performance toEntity() {
     return Performance.builder()
         .id(id)
@@ -37,7 +33,6 @@ public class PerformanceRequest {
         .poster(poster)
         .facility(facility)
         .status(status)
-        .likes(likes)
         .build();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
@@ -2,9 +2,7 @@ package com.halfgallon.withcon.domain.performance.dto.response;
 
 import com.halfgallon.withcon.domain.performance.constant.Status;
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
-import jakarta.persistence.Id;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -30,6 +28,7 @@ public class PerformanceResponse {
 
   public static PerformanceResponse fromEntity(Performance performance) {
     return PerformanceResponse.builder()
+        .id(performance.getId())
         .name(performance.getName())
         .startDate(performance.getStartDate())
         .endDate(performance.getEndDate())

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 @Getter
 public class PerformanceResponse {
 
+  private String id;
+
   private String name;
 
   private LocalDate startDate;

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/PerformanceResponse.java
@@ -12,8 +12,6 @@ import lombok.Getter;
 @Getter
 public class PerformanceResponse {
 
-  private String id;
-
   private String name;
 
   private LocalDate startDate;
@@ -30,7 +28,6 @@ public class PerformanceResponse {
 
   public static PerformanceResponse fromEntity(Performance performance) {
     return PerformanceResponse.builder()
-        .id(performance.getId())
         .name(performance.getName())
         .startDate(performance.getStartDate())
         .endDate(performance.getEndDate())

--- a/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/Performance.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/Performance.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/CustomPerformanceRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/CustomPerformanceRepository.java
@@ -1,10 +1,11 @@
 package com.halfgallon.withcon.domain.performance.repository;
 
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CustomPerformanceRepository {
 
-  List<Performance> searchPerformance(String keyword);
+  Page<Performance> searchPerformance(String keyword, Pageable pageable);
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/CustomPerformanceRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/CustomPerformanceRepository.java
@@ -1,0 +1,10 @@
+package com.halfgallon.withcon.domain.performance.repository;
+
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import java.util.List;
+
+public interface CustomPerformanceRepository {
+
+  List<Performance> searchPerformance(String keyword);
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PerformanceRepository extends JpaRepository<Performance, String> {
+public interface PerformanceRepository extends JpaRepository<Performance, String>, CustomPerformanceRepository {
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/impl/CustomPerformanceRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/impl/CustomPerformanceRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.halfgallon.withcon.domain.performance.repository.impl;
+
+import static com.halfgallon.withcon.domain.performance.entitiy.QPerformance.performance;
+import static com.halfgallon.withcon.domain.performance.entitiy.QPerformanceDetail.performanceDetail;
+
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import com.halfgallon.withcon.domain.performance.repository.CustomPerformanceRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomPerformanceRepositoryImpl implements CustomPerformanceRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<Performance> searchPerformance(String keyword) {
+    return jpaQueryFactory
+        .selectFrom(performance)
+        .leftJoin(performance.performanceDetail, performanceDetail)
+        .where(performance.name.contains(keyword)
+            .or(performanceDetail.actors.contains(keyword)))
+        .distinct()
+        .fetch();
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceService.java
@@ -2,6 +2,7 @@ package com.halfgallon.withcon.domain.performance.service;
 
 import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+import java.util.List;
 
 public interface PerformanceService {
 
@@ -9,4 +10,5 @@ public interface PerformanceService {
   PerformanceResponse findPerformance(String performanceId);
   PerformanceResponse updatePerformance(PerformanceRequest request);
   PerformanceResponse deletePerformance(String performanceId);
+  List<PerformanceResponse> searchPerformance(String keyword);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceService.java
@@ -2,7 +2,8 @@ package com.halfgallon.withcon.domain.performance.service;
 
 import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PerformanceService {
 
@@ -10,5 +11,5 @@ public interface PerformanceService {
   PerformanceResponse findPerformance(String performanceId);
   PerformanceResponse updatePerformance(PerformanceRequest request);
   PerformanceResponse deletePerformance(String performanceId);
-  List<PerformanceResponse> searchPerformance(String keyword);
+  Page<PerformanceResponse> searchPerformance(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImpl.java
@@ -3,10 +3,14 @@ package com.halfgallon.withcon.domain.performance.service.impl;
 import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import com.halfgallon.withcon.domain.performance.entitiy.QPerformance;
+import com.halfgallon.withcon.domain.performance.entitiy.QPerformanceDetail;
 import com.halfgallon.withcon.domain.performance.repository.PerformanceRepository;
 import com.halfgallon.withcon.domain.performance.service.PerformanceService;
 import com.halfgallon.withcon.global.exception.CustomException;
 import com.halfgallon.withcon.global.exception.ErrorCode;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PerformanceServiceImpl implements PerformanceService {
 
   private final PerformanceRepository performanceRepository;
+  private final JPAQueryFactory jpaQueryFactory;
 
   @Override
   @Transactional
@@ -50,5 +55,11 @@ public class PerformanceServiceImpl implements PerformanceService {
     performanceRepository.deleteById(performanceId);
 
     return PerformanceResponse.fromEntity(performance);
+  }
+
+  @Override
+  public List<PerformanceResponse> searchPerformance(String keyword) {
+    return performanceRepository.searchPerformance(keyword)
+        .stream().map(PerformanceResponse::fromEntity).toList();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImpl.java
@@ -3,15 +3,17 @@ package com.halfgallon.withcon.domain.performance.service.impl;
 import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
-import com.halfgallon.withcon.domain.performance.entitiy.QPerformance;
-import com.halfgallon.withcon.domain.performance.entitiy.QPerformanceDetail;
 import com.halfgallon.withcon.domain.performance.repository.PerformanceRepository;
 import com.halfgallon.withcon.domain.performance.service.PerformanceService;
 import com.halfgallon.withcon.global.exception.CustomException;
 import com.halfgallon.withcon.global.exception.ErrorCode;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,8 +60,13 @@ public class PerformanceServiceImpl implements PerformanceService {
   }
 
   @Override
-  public List<PerformanceResponse> searchPerformance(String keyword) {
-    return performanceRepository.searchPerformance(keyword)
-        .stream().map(PerformanceResponse::fromEntity).toList();
+  public Page<PerformanceResponse> searchPerformance(String keyword, Pageable pageable) {
+    Page<Performance> performancePage = performanceRepository.searchPerformance(keyword, pageable);
+    List<PerformanceResponse> performanceResponseList = performancePage.getContent()
+        .stream()
+        .map(PerformanceResponse::fromEntity)
+        .collect(Collectors.toList());
+
+    return new PageImpl<>(performanceResponseList, pageable, performancePage.getTotalElements());
   }
 }

--- a/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
@@ -1,6 +1,8 @@
 package com.halfgallon.withcon.domain.performance.controller;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -25,6 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -111,14 +116,18 @@ class PerformanceControllerTest {
   @DisplayName("공연 검색 완료")
   void searchPerformance_Success() throws Exception {
     String keyword = "keyword";
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<PerformanceResponse> performancePage = Page.empty(pageable);
 
-    given(performanceService.searchPerformance(keyword)).willReturn(getPerformanceResponses());
+    given(performanceService.searchPerformance(keyword, pageable)).willReturn(performancePage);
 
     mockMvc.perform(get("/performance")
         .contentType(MediaType.APPLICATION_JSON)
         .param("keyword", keyword))
+        .andExpect(jsonPath("$.totalPages").exists())
+        .andExpect(jsonPath("$.totalElements").exists())
+        .andExpect(jsonPath("$.content", is(empty())))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(3)))
         .andDo(print());
   }
 
@@ -145,13 +154,5 @@ class PerformanceControllerTest {
         .status(Status.RUNNING)
         .likes(4000L)
         .build();
-  }
-
-  private List<PerformanceResponse> getPerformanceResponses() {
-    return Arrays.asList(
-        getPerformanceResponse(),
-        getPerformanceResponse(),
-        getPerformanceResponse()
-    );
   }
 }

--- a/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
@@ -1,22 +1,24 @@
 package com.halfgallon.withcon.domain.performance.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.halfgallon.withcon.domain.chat.dto.ChatRoomResponse;
 import com.halfgallon.withcon.domain.performance.constant.Status;
 import com.halfgallon.withcon.domain.performance.dto.request.PerformanceRequest;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
 import com.halfgallon.withcon.domain.performance.service.impl.PerformanceServiceImpl;
 import com.halfgallon.withcon.global.annotation.WithCustomMockUser;
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,8 +73,7 @@ class PerformanceControllerTest {
   void findPerformance_Success() throws Exception {
     String id = "id";
 
-    given(performanceService.createPerformance(getPerformanceRequest())).willReturn(getPerformanceResponse());
-
+    given(performanceService.findPerformance(id)).willReturn(getPerformanceResponse());
 
     mockMvc.perform(get("/performance/" + id)
           .contentType(MediaType.APPLICATION_JSON))
@@ -84,7 +85,7 @@ class PerformanceControllerTest {
   @DisplayName("공연 수정 완료")
   void updatePerformance_Success() throws Exception {
 
-    given(performanceService.createPerformance(getPerformanceRequest())).willReturn(getPerformanceResponse());
+    given(performanceService.updatePerformance(getPerformanceRequest())).willReturn(getPerformanceResponse());
 
     mockMvc.perform(put("/performance")
         .contentType(MediaType.APPLICATION_JSON)
@@ -98,7 +99,7 @@ class PerformanceControllerTest {
   void deletePerformance_Success() throws Exception {
     String id = "id";
 
-    given(performanceService.createPerformance(getPerformanceRequest())).willReturn(getPerformanceResponse());
+    given(performanceService.deletePerformance(id)).willReturn(getPerformanceResponse());
 
     mockMvc.perform(delete("/performance/" + id)
         .contentType(MediaType.APPLICATION_JSON))
@@ -106,7 +107,22 @@ class PerformanceControllerTest {
         .andDo(print());
   }
 
-  private static PerformanceRequest getPerformanceRequest() {
+  @Test
+  @DisplayName("공연 검색 완료")
+  void searchPerformance_Success() throws Exception {
+    String keyword = "keyword";
+
+    given(performanceService.searchPerformance(keyword)).willReturn(getPerformanceResponses());
+
+    mockMvc.perform(get("/performance")
+        .contentType(MediaType.APPLICATION_JSON)
+        .param("keyword", keyword))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(3)))
+        .andDo(print());
+  }
+
+  private PerformanceRequest getPerformanceRequest() {
     return PerformanceRequest.builder()
         .id("id")
         .name("name")
@@ -119,9 +135,8 @@ class PerformanceControllerTest {
         .build();
   }
 
-  private static PerformanceResponse getPerformanceResponse() {
+  private PerformanceResponse getPerformanceResponse() {
     return PerformanceResponse.builder()
-        .id("id")
         .name("name")
         .startDate(LocalDate.ofEpochDay(2024-02-18))
         .endDate(LocalDate.ofEpochDay(2024-02-20))
@@ -132,4 +147,11 @@ class PerformanceControllerTest {
         .build();
   }
 
+  private List<PerformanceResponse> getPerformanceResponses() {
+    return Arrays.asList(
+        getPerformanceResponse(),
+        getPerformanceResponse(),
+        getPerformanceResponse()
+    );
+  }
 }

--- a/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImplTest.java
@@ -1,10 +1,8 @@
 package com.halfgallon.withcon.domain.performance.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -17,7 +15,10 @@ import com.halfgallon.withcon.domain.performance.repository.PerformanceRepositor
 import com.halfgallon.withcon.global.exception.CustomException;
 import com.halfgallon.withcon.global.exception.ErrorCode;
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,7 +87,8 @@ class PerformanceServiceImplTest {
         () -> performanceService.findPerformance(id));
 
     // then
-    assertThat(ErrorCode.PERFORMANCE_NOT_FOUND.getDescription()).isEqualTo(customException.getMessage());
+    assertThat(ErrorCode.PERFORMANCE_NOT_FOUND.getDescription()).isEqualTo(
+        customException.getMessage());
   }
 
   @Test
@@ -128,12 +130,32 @@ class PerformanceServiceImplTest {
     verify(performanceRepository, times(1)).deleteById(id);
   }
 
-  private static PerformanceRequest getPerformanceRequest() {
+  @Test
+  @DisplayName("공연 검색 완료")
+  void searchPerformance_Success() {
+    //given
+    PerformanceRequest request = getPerformanceRequest();
+    String keyword = "keyword";
+    List<PerformanceResponse> expectedResponse = getPerformances().stream()
+        .map(PerformanceResponse::fromEntity).toList();
+
+    // PerformanceRepository의 searchPerformance 메소드가 호출되면 PerformanceResponse 객체의 리스트를 반환하도록 설정합니다.
+    given(performanceRepository.searchPerformance(keyword)).willReturn(getPerformances());
+
+    List<PerformanceResponse> actualResponse = performanceService.searchPerformance(
+        keyword);
+
+    assertThat(expectedResponse.stream().map(PerformanceResponse::getId)
+        .collect(Collectors.toList())).containsExactlyElementsOf(
+        expectedResponse.stream().map(PerformanceResponse::getId).toList());
+  }
+
+  private PerformanceRequest getPerformanceRequest() {
     return PerformanceRequest.builder()
         .id("id")
         .name("name")
-        .startDate(LocalDate.ofEpochDay(2024-02-18))
-        .endDate(LocalDate.ofEpochDay(2024-02-20))
+        .startDate(LocalDate.ofEpochDay(2024 - 02 - 18))
+        .endDate(LocalDate.ofEpochDay(2024 - 02 - 20))
         .poster("asdfler")
         .facility("공연 장소")
         .status(Status.RUNNING)
@@ -141,16 +163,24 @@ class PerformanceServiceImplTest {
         .build();
   }
 
-  private static PerformanceResponse getPerformanceResponse() {
+  private PerformanceResponse getPerformanceResponse() {
     return PerformanceResponse.builder()
         .id("id")
         .name("name")
-        .startDate(LocalDate.ofEpochDay(2024-02-18))
-        .endDate(LocalDate.ofEpochDay(2024-02-20))
+        .startDate(LocalDate.ofEpochDay(2024 - 02 - 18))
+        .endDate(LocalDate.ofEpochDay(2024 - 02 - 20))
         .poster("asdfler")
         .facility("공연 장소")
         .status(Status.RUNNING)
         .likes(4000L)
         .build();
+  }
+
+  private List<Performance> getPerformances() {
+    return Arrays.asList(
+        getPerformanceRequest().toEntity(),
+        getPerformanceRequest().toEntity(),
+        getPerformanceRequest().toEntity()
+    );
   }
 }


### PR DESCRIPTION
## 📝작업 내용

 - 공연 검색 기능 구현


## 💬리뷰 참고사항
![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/102509248/be1f9ce1-67b1-49e6-b935-4b040e43cffc)

- 공연 배우 명단 혹은 공연 제목에 키워드가 들어간 모든 공연을 조회합니다.
- 공연 배우는 공연 세부 정보 테이블의 필드이고, 공연 제목은 공연 테이블의 필드입니다.
- 공연 세부 정보 엔티티와 공연 엔티티는 동일한 Id를 사용합니다. 
- 반환 타입이 PerformanceResponse이기에 공연 테이블에서 제목에 키워드가 포함되는 공연을 찾을 순 있지만, 공연 세부 정보에서 찾았을 때는 Id를 통해 DB를 한번 더 조회해서 공연을 찾아야 합니다.
- 따라서 한 번의 접근으로 필요한 데이터를 가져오는 것이 효율적이라 생각하여 QueryDSL을 사용했습니다.


(close) #75 