### PR TITLE
[feat] 회원가입 시 username, phoneNumber 중복체크 API 추가

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/controller/AuthController.java
@@ -30,6 +30,18 @@ public class AuthController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  @PostMapping("/username-duplication-check")
+  public ResponseEntity<?> usernameDuplicationCheck(@RequestBody String username) {
+    authService.usernameDuplicationCheck(username);
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/phone-number-duplication-check")
+  public ResponseEntity<?> phoneNumberDuplicationCheck(@RequestBody String phoneNumber) {
+    authService.phoneNumberDuplicationCheck(phoneNumber);
+    return ResponseEntity.ok().build();
+  }
+
   @PostMapping("/reissue")
   public ResponseEntity<Void> reissueAccessToken(
       @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {

--- a/src/main/java/com/halfgallon/withcon/domain/auth/service/AuthService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/service/AuthService.java
@@ -10,7 +10,19 @@ public interface AuthService {
   void join(AuthJoinRequest authJoinRequest);
 
   /**
+   * username 중복 체크
+   */
+  void usernameDuplicationCheck(String username);
+
+  /**
+   * phoneNumber 중복 체크
+   */
+  void phoneNumberDuplicationCheck(String phoneNumber);
+
+  /**
    * 액세스 토큰 재발급
    */
   String reissueAccessToken(String refreshToken);
+
+
 }

--- a/src/main/java/com/halfgallon/withcon/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.auth.service;
 
+import static com.halfgallon.withcon.global.exception.ErrorCode.DUPLICATE_PHONE_NUMBER;
 import static com.halfgallon.withcon.global.exception.ErrorCode.DUPLICATE_USERNAME;
 import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.halfgallon.withcon.global.exception.ErrorCode.REFRESH_TOKEN_COOKIE_IS_EMPTY;
@@ -35,13 +36,35 @@ public class AuthServiceImpl implements AuthService {
    */
   @Override
   public void join(AuthJoinRequest request) {
-    if (memberRepository.existsByUsername(request.getUsername())) {
-      throw new CustomException(DUPLICATE_USERNAME);
-    }
+    usernameDuplicationValidate(request.getUsername());
 
     String encodedPassword = passwordEncoder.encode(request.getPassword());
 
     memberRepository.save(request.toEntity(encodedPassword));
+  }
+
+  /**
+   * username 중복 체크
+   */
+  @Override
+  public void usernameDuplicationCheck(String username) {
+    usernameDuplicationValidate(username);
+  }
+
+  private void usernameDuplicationValidate(String username) {
+    if (memberRepository.existsByUsername(username)) {
+      throw new CustomException(DUPLICATE_USERNAME);
+    }
+  }
+
+  /**
+   * phoneNumber 중복 체크
+   */
+  @Override
+  public void phoneNumberDuplicationCheck(String phoneNumber) {
+    if (memberRepository.existsByPhoneNumber(phoneNumber)) {
+      throw new CustomException(DUPLICATE_PHONE_NUMBER);
+    }
   }
 
   /**

--- a/src/main/java/com/halfgallon/withcon/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/repository/MemberRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   boolean existsByUsername(String username);
+  boolean existsByPhoneNumber(String phoneNumber);
 
   Optional<Member> findByUsername(String username);
 

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
    */
   DUPLICATE_CHATROOM(CONFLICT.value(), "이미 존재하는 채팅방입니다."),
   DUPLICATE_USERNAME(CONFLICT.value(), "이미 사용하고 있는 ID 입니다."),
+  DUPLICATE_PHONE_NUMBER(CONFLICT.value(), "이미 사용하고 있는 핸드폰 번호입니다."),
 
   /**
    * 500 Internal Server Error

--- a/src/test/java/com/halfgallon/withcon/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/controller/AuthControllerTest.java
@@ -71,6 +71,32 @@ class AuthControllerTest {
   }
 
   @Test
+  @DisplayName("username 중복 체크 요청")
+  void usernameDuplicationCheck_Success() throws Exception {
+    String username = "username";
+
+    mockMvc.perform(post("/auth/username-duplication-check")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(username))
+        .andExpect(status().isOk());
+
+    verify(authService, times(1)).usernameDuplicationCheck(username);
+  }
+
+  @Test
+  @DisplayName("phoneNumber 중복 체크 요청")
+  void phoneNumberDuplicationCheck_Success() throws Exception {
+    String phoneNumber = "010-1234-5678";
+
+    mockMvc.perform(post("/auth/phone-number-duplication-check")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(phoneNumber))
+        .andExpect(status().isOk());
+
+    verify(authService, times(1)).phoneNumberDuplicationCheck(phoneNumber);
+  }
+
+  @Test
   @DisplayName("액세스토큰 재발급 요청")
   void reissueAccessToken_Success() throws Exception {
     String refreshToken = "RefreshToken";

--- a/src/test/java/com/halfgallon/withcon/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/service/AuthServiceImplTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import com.halfgallon.withcon.domain.auth.dto.request.AuthJoinRequest;
 import com.halfgallon.withcon.domain.auth.entity.RefreshToken;
 import com.halfgallon.withcon.domain.auth.manager.JwtManager;
-import com.halfgallon.withcon.domain.auth.repository.AccessTokenRepository;
 import com.halfgallon.withcon.domain.auth.repository.RefreshTokenRepository;
 import com.halfgallon.withcon.domain.member.entity.Member;
 import com.halfgallon.withcon.domain.member.repository.MemberRepository;
@@ -45,9 +44,6 @@ class AuthServiceImplTest {
 
   @Mock
   private PasswordEncoder passwordEncoder;
-
-  @Mock
-  private AccessTokenRepository accessTokenRepository;
 
   @Mock
   private RefreshTokenRepository refreshTokenRepository;


### PR DESCRIPTION
## 📝작업 내용

회원가입 시 username, phoneNumber 중복체크 API를 추가하였습니다.
클라이언트에서 '중복확인' 버튼을 클릭할 시 동작하는 API 입니다.

## 💬리뷰 참고사항

## #️⃣연관된 이슈

(close) #이슈번호
