### PR TITLE
[feat] 회원 프로필 사진 업로드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
 	ext {
 		queryDslVersion = "5.0.0"
 		springCloudVersion = "2022.0.5"
+		springCloudAwsVersion = "3.1.0"
 	}
 }
 
@@ -73,6 +74,11 @@ dependencies {
 	// Open-Feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// AWS-S3
+	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:${springCloudAwsVersion}")
+	implementation'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/halfgallon/withcon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/controller/MemberController.java
@@ -9,9 +9,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +34,14 @@ public class MemberController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestBody UpdateMemberRequest updateMemberRequest) {
     memberService.updateMember(userDetails.getId(), updateMemberRequest);
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/profile-image")
+  public ResponseEntity<?> uploadProfileImage(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestPart MultipartFile image) {
+    memberService.uploadProfileImage(userDetails.getId(), image);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
@@ -46,12 +46,19 @@ public class Member extends BaseTimeEntity {
 
   @Column
   private String phoneNumber;
-  
+
+  @Column
+  private String profileImage;
+
   @OneToMany
   private List<PerformanceLike> likes;
 
   public void update(UpdateMemberRequest request) {
     this.nickname = request.nickname();
     this.phoneNumber = request.phoneNumber();
+  }
+
+  public void updateProfileImage(String profileImageUrl) {
+    this.profileImage = profileImageUrl;
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/member/service/MemberService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.halfgallon.withcon.domain.member.service;
 
 import com.halfgallon.withcon.domain.member.dto.request.UpdateMemberRequest;
 import com.halfgallon.withcon.domain.member.dto.response.MemberMyInfoResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
 
@@ -16,7 +17,14 @@ public interface MemberService {
   void updateMember(Long memberId, UpdateMemberRequest request);
 
   /**
+   * 회원 프로필 사진 업로드
+   */
+  void uploadProfileImage(Long memberId, MultipartFile image);
+
+  /**
    * 회원 탈퇴
    */
   void deleteMember(Long memberId);
+
+
 }

--- a/src/main/java/com/halfgallon/withcon/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/service/impl/MemberServiceImpl.java
@@ -8,15 +8,18 @@ import com.halfgallon.withcon.domain.member.entity.Member;
 import com.halfgallon.withcon.domain.member.repository.MemberRepository;
 import com.halfgallon.withcon.domain.member.service.MemberService;
 import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.storage.service.StorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
   private final MemberRepository memberRepository;
+  private final StorageService storageService;
 
   @Override
   public MemberMyInfoResponse getMyInformation(Long memberId) {
@@ -29,6 +32,14 @@ public class MemberServiceImpl implements MemberService {
   public void updateMember(Long memberId, UpdateMemberRequest request) {
     Member findMember = findMemberOrThrow(memberId);
     findMember.update(request);
+  }
+
+  @Override
+  @Transactional
+  public void uploadProfileImage(Long memberId, MultipartFile image) {
+    Member findMember = findMemberOrThrow(memberId);
+    String profileImageUrl = storageService.uploadFile(image);
+    findMember.updateProfileImage(profileImageUrl);
   }
 
   @Override

--- a/src/main/java/com/halfgallon/withcon/global/storage/service/StorageService.java
+++ b/src/main/java/com/halfgallon/withcon/global/storage/service/StorageService.java
@@ -1,0 +1,9 @@
+package com.halfgallon.withcon.global.storage.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+
+  String uploadFile(MultipartFile file);
+
+}

--- a/src/main/java/com/halfgallon/withcon/global/storage/service/impl/AwsS3Service.java
+++ b/src/main/java/com/halfgallon/withcon/global/storage/service/impl/AwsS3Service.java
@@ -1,0 +1,45 @@
+package com.halfgallon.withcon.global.storage.service.impl;
+
+import static com.halfgallon.withcon.global.exception.ErrorCode.INTERVAL_SERVER_ERROR;
+
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.storage.service.StorageService;
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Template;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service implements StorageService {
+
+  private final S3Template s3Template;
+
+  @Value("${aws.s3.bucketName}")
+  private String bucketName;
+
+  @Override
+  public String uploadFile(MultipartFile file) {
+    String originalFileName = file.getOriginalFilename();
+    String extension = StringUtils.getFilenameExtension(originalFileName);
+    String fileName = UUID.randomUUID() + "." + extension;
+
+    ObjectMetadata objectMetadata = ObjectMetadata.builder()
+        .contentType(file.getContentType())
+        .contentLength(file.getSize())
+        .build();
+
+    try (InputStream inputStream = file.getInputStream()) {
+      return s3Template.upload(bucketName, fileName, inputStream, objectMetadata).getURL()
+          .toString();
+    } catch (IOException e) {
+      throw new CustomException(INTERVAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/test/java/com/halfgallon/withcon/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/member/controller/MemberControllerTest.java
@@ -1,9 +1,12 @@
 package com.halfgallon.withcon.domain.member.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -18,10 +21,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(MemberController.class)
 class MemberControllerTest {
@@ -82,6 +87,29 @@ class MemberControllerTest {
 
     // then
     verify(memberService).updateMember(memberId, request);
+  }
+
+  @Test
+  @DisplayName("회원 프로필 사진 업로드")
+  @WithCustomMockUser
+  void updateProfileImage() throws Exception {
+    // given
+    MockMultipartFile image = new MockMultipartFile("image", "test.jpg", "image/jpeg",
+        "테스트이미지 내용".getBytes());
+
+    CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext()
+        .getAuthentication().getPrincipal();
+
+    Long memberId = principal.getId();
+
+    doNothing().when(memberService).uploadProfileImage(any(Long.class), any(MultipartFile.class));
+
+    // when
+    mockMvc.perform(multipart("/member/profile-image").file(image))
+        .andExpect(status().isOk());
+
+    // then
+    verify(memberService).uploadProfileImage(memberId, image);
   }
 
   @Test


### PR DESCRIPTION
## 📝작업 내용

회원 프로필 사진을 AWS의 S3에 저장하고자 `Spring Cloud AWS S3` 디펜던시를 추가하였습니다.
이미지 업로드 기능을 추가하였습니다.

## 💬리뷰 참고사항
포스트맨으로 테스트결과 DB에 성공적으로 저장되었습니다.
![스크린샷 2024-02-15 00 05 55](https://github.com/HalfGallonTeam/WithCon_BE/assets/68311264/ad32a71a-e40f-41a7-8c3f-3c755528b552)

또한 S3 버킷에도 정상적으로 저장되는 것을 확인하였습니다.
![스크린샷 2024-02-15 00 06 52](https://github.com/HalfGallonTeam/WithCon_BE/assets/68311264/797b408a-3b9e-435d-8771-1e6c658e44b3)



## #️⃣연관된 이슈
