### PR TITLE
[refactor] 채팅방 방장 Response 변경 

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantDto.java
@@ -10,8 +10,7 @@ public record ChatParticipantDto(
     String password,
     LoginType loginType,
     String nickName,
-    String phoneNumber,
-    boolean isManager
+    String phoneNumber
 ) {
 
   public static ChatParticipantDto fromEntity(ChatParticipant chatParticipant) {
@@ -21,7 +20,6 @@ public record ChatParticipantDto(
         .loginType(chatParticipant.getMember().getLoginType())
         .nickName(chatParticipant.getMember().getNickname())
         .phoneNumber(chatParticipant.getMember().getPhoneNumber())
-        .isManager(chatParticipant.isManager())
         .build();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomEnterResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomEnterResponse.java
@@ -8,6 +8,7 @@ public record ChatRoomEnterResponse(
     Long chatRoomId,
     Long performanceId,
     String roomName,
+    String managerName,
     Integer userCount,
     List<ChatParticipantDto> chatParticipants
 ) {

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
@@ -8,9 +8,10 @@ public record ChatRoomRequest(
     Long performanceId,
     List<String> tags
 ) {
-  public ChatRoom toEntity() {
+  public ChatRoom toEntity(String username) {
     return ChatRoom.builder()
         .name(this.roomName)
+        .managerName(username)
         .build();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomResponse.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 public record ChatRoomResponse(
     Long chatRoomId,
     String roomName,
+    String managerName,
     Long performanceId,
     Integer userCount,
     List<String> tags,
@@ -22,6 +23,7 @@ public record ChatRoomResponse(
     return ChatRoomResponse.builder()
         .chatRoomId(chatRoom.getId())
         .roomName(chatRoom.getName())
+        .managerName(chatRoom.getManagerName())
         .performanceId(Long.valueOf(chatRoom.getPerformance().getId()))
         .userCount(chatRoom.getUserCount())
         .tags(chatRoom.getTags().stream().map(Tag::getName).toList())

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatParticipant.java
@@ -32,8 +32,4 @@ public class ChatParticipant {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chatRoom_id")
   private ChatRoom chatRoom;
-
-  @Builder.Default
-  private boolean isManager = false;
-
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
@@ -49,6 +49,9 @@ public class ChatRoom extends BaseTimeEntity {
   @JoinColumn(name = "performance_id")
   private Performance performance;
 
+  @Column(nullable = false)
+  private String managerName;
+
   public void updateUserCount() {
     this.userCount = this.chatParticipants.size();
   }
@@ -70,4 +73,5 @@ public class ChatRoom extends BaseTimeEntity {
   public void updatePerformance(Performance performance) {
     this.performance = performance;
   }
+
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatRoomRepository.java
@@ -11,4 +11,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   boolean existsByName(String name);
 
   Page<ChatRoom> findAllByPerformance_Id(String performanceId, Pageable pageable);
+
+  boolean existsByManagerName(String managerName);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatParticipantRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatParticipantRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface CustomChatParticipantRepository {
 
-  boolean checkRoomManager(Long memberId);
+  boolean checkRoomManagerName(String managerName);
 
   Page<ChatParticipant> findAllMyChattingRoom(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatParticipantRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatParticipantRepositoryImpl.java
@@ -19,14 +19,14 @@ public class CustomChatParticipantRepositoryImpl implements CustomChatParticipan
   private final JPAQueryFactory jpaQueryFactory;
 
   @Override
-  public boolean checkRoomManager(Long memberId) {
-    Integer fetchOne = jpaQueryFactory.selectOne()
+  public boolean checkRoomManagerName(String managerName) {
+    Integer i = jpaQueryFactory.selectOne()
         .from(chatParticipant)
-        .where(chatParticipant.member.id.eq(memberId),
-            chatParticipant.isManager.eq(true))
+        .leftJoin(chatParticipant.chatRoom, chatRoom)
+        .where(chatRoom.managerName.eq(managerName))
         .fetchFirst();
 
-    return fetchOne != null;
+    return i != null;
   }
 
   @Override

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -56,9 +56,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     Member member = memberRepository.findById(customUserDetails.getId())
         .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
-    validationCreateChatroom(request, member.getId());
+    validationCreateChatroom(request, member.getUsername());
 
-    ChatRoom chatRoom = chatRoomRepository.save(request.toEntity());
+    ChatRoom chatRoom = chatRoomRepository.save(request.toEntity(member.getUsername()));
 
     //채팅방 생성 시에 공연 정보 추가
     chatRoom.updatePerformance(performanceRepository.findById(String.valueOf(request.performanceId()))
@@ -69,7 +69,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         ChatParticipant.builder()
             .chatRoom(chatRoom)
             .member(member)
-            .isManager(true)
             .build()));
 
     //태그가 있는 경우에만 - 해당 태그 저장
@@ -102,10 +101,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
           if (tagSearch == null) {
             return TagSearch.builder()
-              .id(tag.getId().toString())
-              .name(tag.getName())
-              .tagCount(1)
-              .build();
+                .id(tag.getId().toString())
+                .name(tag.getName())
+                .tagCount(1)
+                .build();
           } else {
             Integer count = tagRepository.countTagByName(tag.getName());
             tagSearchRepository.updateTagCount(tagSearch.getId(), tag.getName(), count);
@@ -156,6 +155,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     return ChatRoomEnterResponse.builder()
         .roomName(chatRoom.getName())
         .chatRoomId(chatRoomId)
+        .managerName(chatRoom.getManagerName())
         .userCount(chatRoom.getUserCount())
         .chatParticipants(chatParticipants)
         .performanceId(Long.valueOf(chatRoom.getPerformance().getId()))
@@ -172,8 +172,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     participantRepository.delete(participant);
     participant.getChatRoom().removeChatParticipant(participant);
 
+    ChatRoomResponse response = ChatRoomResponse.fromEntity(participant.getChatRoom());
+
     //채팅방 인원이 전부 나간 경우 or 채팅방 방장이 방을 없앤 경우
-    if (participant.getChatRoom().getUserCount() <= 0 || participant.isManager()) {
+    if (response.userCount() <= 0 || response.managerName().equals(customUserDetails.getUsername())) {
       chatRoomRepository.delete(participant.getChatRoom());
     }
   }
@@ -196,11 +198,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Transactional
   public ChatRoomResponse kickChatRoom(CustomUserDetails customUserDetails, Long chatRoomId,
       Long memberId) {
+    //현재 채팅방에서 강퇴할 인원 참여 여부 체크
     ChatParticipant chatParticipant = participantRepository.findByMemberIdAndChatRoomId(
             memberId, chatRoomId)
         .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
-    if (participantRepository.checkRoomManager(customUserDetails.getId())) {
+    if (participantRepository.checkRoomManagerName(customUserDetails.getUsername())) {
       participantRepository.delete(chatParticipant);
       chatParticipant.getChatRoom().removeChatParticipant(chatParticipant);
     }
@@ -211,13 +214,13 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   /**
    * 채팅방 생성 유효성 검사
    */
-  private void validationCreateChatroom(ChatRoomRequest request, Long memberId) {
+  private void validationCreateChatroom(ChatRoomRequest request, String username) {
     //채팅방 이름 검사
     if (chatRoomRepository.existsByName(request.roomName())) {
       throw new CustomException(DUPLICATE_CHATROOM);
     }
     //채팅방은 1인당 1개만 생성이 가능하다.
-    if (participantRepository.checkRoomManager(memberId)) {
+    if (chatRoomRepository.existsByManagerName(username)) {
       throw new CustomException(USER_JUST_ONE_CREATE_CHATROOM);
     }
   }

--- a/src/test/http/auth.http
+++ b/src/test/http/auth.http
@@ -3,10 +3,10 @@ POST http://localhost:8080/auth/join
 Content-Type: application/json
 
 {
-  "username": "abcd7787",
+  "username": "part1",
   "password": "1q2w3e4r!",
-  "nickname": "위콘2",
-  "phoneNumber": "01077744567"
+  "nickname": "위콘1",
+  "phoneNumber": "0102132147"
 }
 
 ### 로그인
@@ -14,15 +14,20 @@ POST http://localhost:8080/auth/login
 Content-Type: application/json
 
 {
-  "username": "abcd7787",
+  "username": "manager1",
   "password": "1q2w3e4r!"
 }
+
+> {%
+  client.global.set("accessToken", response.headers.valueOf("Authorization"))
+  client.log("엑세스 토큰: " + client.global.get("accessToken"));
+%}
+
 
 ### 네이버 로그인 테스트(인증코드로 요청)
 POST http://localhost:8080/auth/naver
 Content-Type: text/plain
 
-fkcdtW9su2RL29FaRY
 
 ### 네이버 로그인 필터 테스트
 POST http://localhost:8080/auth/oauth2/login
@@ -42,7 +47,3 @@ Content-Type: application/json
   "authorizationCode": "rY0ijkxxrIgHpWBFPZteh-Ur0DYby7pypAoC9MVIkTwUAdwr9-WxE6dT3OwKPXWaAAABjX-XxTH-oZq-Jypvmw"
 }
 
-> {%
-  client.global.set("accessToken", response.headers.valueOf("Authorization"))
-  client.log("엑세스 토큰: " + client.global.get("accessToken"));
-  %}

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -4,9 +4,8 @@ Content-Type: application/json
 Authorization: {{accessToken}}
 
 {
-  "memberId": 2,
-  "roomName": "채팅방2",
-  "performanceId": 1,
+  "roomName": "채팅방7",
+  "performanceId": 7,
   "tags": ["#123", "#서울", "위드"]
 }
 
@@ -19,7 +18,7 @@ Content-Type: application/json
 
 ### 채팅방 입장
 < {%
-  request.variables.set("chatRoomId", "1")
+  request.variables.set("chatRoomId", "5")
 %}
 GET http://localhost:8080/chatRoom/{{chatRoomId}}/enter
 Content-Type: application/json
@@ -27,7 +26,7 @@ Authorization: {{accessToken}}
 
 ### 채팅방 퇴장
 < {%
-  request.variables.set("chatRoomId", "1")
+  request.variables.set("chatRoomId", "5")
 %}
 DELETE http://localhost:8080/chatRoom/{{chatRoomId}}/exit
 Content-Type: application/json
@@ -43,8 +42,8 @@ Authorization: {{accessToken}}
 
 ### 채팅방 강퇴
 < {%
-  request.variables.set("chatRoomId", "13")
-  request.variables.set("memberId", "12")
+  request.variables.set("chatRoomId", "5")
+  request.variables.set("memberId", "6")
 %}
 DELETE http://localhost:8080/chatRoom/{{chatRoomId}}/kick/{{memberId}}
 Content-Type: application/json


### PR DESCRIPTION
## 📝작업 내용
1. 채팅방 방장여부 테이블 및 response 변경
   - ChatParticipant.isManager -> ChatRoom.managerName
   - response 진행 시에 `managerName` 추가(chatRoom)
   - response 진행 시에 `isManager` 삭제(ChatParticipant)
   - 방장 강퇴 서비스 진행 시에 기존 내용으로 진행 시에 UI 설정 불합리로 인한 변경(프론트앤드 요청사항)
   
2. 방장 여부 확인 JPA 변경
   - 기존 `memberId` -> `username` 으로 해당 채팅방의 방장을 확인하도록 변경

## 💬리뷰 참고사항
- [x] API 테스트 진행

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/040d0e81-6e81-4ec1-882e-d787e8b81633)

- [x] 테스트 코드 작성

## #️⃣연관된 이슈
close #87
