### PR TITLE
[feat] 채팅방 참여자 유저프로필 정보 반환

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantDto.java
@@ -8,16 +8,18 @@ import lombok.Builder;
 public record ChatParticipantDto(
     String username,
     String password,
+    String userProfile,
     LoginType loginType,
     String nickName,
     String phoneNumber,
     boolean isManager
 ) {
 
-  public static ChatParticipantDto fromEntity(ChatParticipant chatParticipant) {
+  public static ChatParticipantDto fromEntity(ChatParticipant chatParticipant, String userProfile) {
     return ChatParticipantDto.builder()
         .username(chatParticipant.getMember().getUsername())
         .password(chatParticipant.getMember().getPassword())
+        .userProfile(userProfile)
         .loginType(chatParticipant.getMember().getLoginType())
         .nickName(chatParticipant.getMember().getNickname())
         .phoneNumber(chatParticipant.getMember().getPhoneNumber())

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -151,7 +151,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     //채팅방 참여하고 있는 인원 리스트
     List<ChatParticipantDto> chatParticipants = chatRoom.getChatParticipants()
         .stream()
-        .map(ChatParticipantDto::fromEntity).toList();
+        .map(part -> ChatParticipantDto.fromEntity(part, member.getProfileImage())).toList();
 
     return ChatRoomEnterResponse.builder()
         .roomName(chatRoom.getName())

--- a/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/controller/PerformanceControllerTest.java
@@ -1,7 +1,6 @@
 package com.halfgallon.withcon.domain.performance.controller;
 
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -19,8 +18,6 @@ import com.halfgallon.withcon.domain.performance.dto.response.PerformanceRespons
 import com.halfgallon.withcon.domain.performance.service.impl.PerformanceServiceImpl;
 import com.halfgallon.withcon.global.annotation.WithCustomMockUser;
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -140,7 +137,6 @@ class PerformanceControllerTest {
         .poster("asdfler")
         .facility("공연 장소")
         .status(Status.RUNNING)
-        .likes(4000L)
         .build();
   }
 

--- a/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceServiceImplTest.java
@@ -15,10 +15,7 @@ import com.halfgallon.withcon.domain.performance.repository.PerformanceRepositor
 import com.halfgallon.withcon.global.exception.CustomException;
 import com.halfgallon.withcon.global.exception.ErrorCode;
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -160,7 +157,6 @@ class PerformanceServiceImplTest {
         .poster("asdfler")
         .facility("공연 장소")
         .status(Status.RUNNING)
-        .likes(4000L)
         .build();
   }
 


### PR DESCRIPTION
## 📝작업 내용

- 채팅참여자 response userProfile 추가

- 채팅방 참여자 정보 Dto 변환 시에 유저프로필 내용 추가

## 💬리뷰 참고사항

- [x] API 테스트

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/e47d0a5a-009f-4833-bad6-213defec5414)


## #️⃣연관된 이슈

close #89 
