### PR TITLE
[Feat] 공연 찜 기능 

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import com.halfgallon.withcon.domain.member.constant.LoginType;
 import com.halfgallon.withcon.domain.member.dto.request.UpdateMemberRequest;
 import com.halfgallon.withcon.domain.performance.entitiy.PerformanceLike;
 import com.halfgallon.withcon.global.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +15,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,12 +48,12 @@ public class Member extends BaseTimeEntity {
 
   @Column
   private String phoneNumber;
+  
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default private List<PerformanceLike> likes = new ArrayList<>();
 
   @Column
   private String profileImage;
-
-  @OneToMany
-  private List<PerformanceLike> likes;
 
   public void update(UpdateMemberRequest request) {
     this.nickname = request.nickname();

--- a/src/main/java/com/halfgallon/withcon/domain/notification/dto/ChatRoomNotificationRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/dto/ChatRoomNotificationRequest.java
@@ -3,7 +3,7 @@ package com.halfgallon.withcon.domain.notification.dto;
 import com.halfgallon.withcon.domain.chat.constant.MessageType;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,16 +13,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ChatRoomNotificationRequest {
 
-  @NotBlank
+  @NotNull
   private Long chatRoomId;
 
-  @NotBlank
+  @NotNull
   private Long performanceId;
 
-  @NotBlank
+  @NotNull
   private Long targetId; // 입장/퇴장/강퇴의 대상이 된 사람
 
-  @NotBlank
+  @NotNull
   @Enumerated(value = EnumType.STRING)
   private MessageType messageType;
 

--- a/src/main/java/com/halfgallon/withcon/domain/notification/dto/RedisChannelRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/dto/RedisChannelRequest.java
@@ -1,6 +1,6 @@
 package com.halfgallon.withcon.domain.notification.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,10 +8,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RedisChannelRequest {
 
-  @NotBlank
+  @NotNull
   private Long performanceId;
 
-  @NotBlank
+  @NotNull
   private Long chatRoomId;
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/notification/dto/VisibleRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/dto/VisibleRequest.java
@@ -3,7 +3,7 @@ package com.halfgallon.withcon.domain.notification.dto;
 import com.halfgallon.withcon.domain.notification.constant.VisibleType;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,13 +13,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class VisibleRequest {
 
-  @NotBlank
+  @NotNull
   private Long performanceId;
 
-  @NotBlank
+  @NotNull
   private Long chatRoomId;
 
-  @NotBlank
+  @NotNull
   @Enumerated(value = EnumType.STRING)
   private VisibleType visibleType;
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/constant/Genre.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/constant/Genre.java
@@ -1,5 +1,8 @@
 package com.halfgallon.withcon.domain.performance.constant;
 
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.exception.ErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,4 +14,11 @@ public enum Genre {
   THEATER("연극");
 
   private final String description;
+
+  public static Genre fromDescription(String description) {
+    return Arrays.stream(Genre.values())
+        .filter(genre ->  genre.getDescription().equals(description))
+        .findFirst()
+        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_PARAMETER));
+  }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/constant/Genre.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/constant/Genre.java
@@ -14,11 +14,4 @@ public enum Genre {
   THEATER("연극");
 
   private final String description;
-
-  public static Genre fromDescription(String description) {
-    return Arrays.stream(Genre.values())
-        .filter(genre ->  genre.getDescription().equals(description))
-        .findFirst()
-        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_PARAMETER));
-  }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/constant/Genre.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/constant/Genre.java
@@ -1,8 +1,5 @@
 package com.halfgallon.withcon.domain.performance.constant;
 
-import com.halfgallon.withcon.global.exception.CustomException;
-import com.halfgallon.withcon.global.exception.ErrorCode;
-import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceLikeController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceLikeController.java
@@ -7,6 +7,9 @@ import com.halfgallon.withcon.domain.performance.service.PerformanceLikeService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,11 +58,12 @@ public class PerformanceLikeController {
   }
 
   @GetMapping("/favorite")
-  public ResponseEntity<List<PerformanceResponse>> findLikes(
-      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+  public ResponseEntity<Page<PerformanceResponse>> findLikes(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PageableDefault(size = 10) Pageable pageable) {
 
     return ResponseEntity.ok(
-        performanceLikeService.findLikes(customUserDetails.getId()));
+        performanceLikeService.findLikes(customUserDetails.getId(), pageable));
   }
 
   // 나의 찜 공연 id 목록

--- a/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceLikeController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceLikeController.java
@@ -60,7 +60,7 @@ public class PerformanceLikeController {
   @GetMapping("/favorite")
   public ResponseEntity<Page<PerformanceResponse>> findLikes(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PageableDefault(size = 10) Pageable pageable) {
+      @PageableDefault() Pageable pageable) {
 
     return ResponseEntity.ok(
         performanceLikeService.findLikes(customUserDetails.getId(), pageable));

--- a/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceLikeController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceLikeController.java
@@ -30,11 +30,11 @@ public class PerformanceLikeController {
   // 장르별 찜 많은순 5개 조회
   @GetMapping("/best")
   public ResponseEntity<MainPagePerformanceResponse> bestPerformance(
-      @RequestParam String category,
+      @RequestParam String genre,
       @RequestParam int size) {
 
     return ResponseEntity.ok(
-        performanceLikeService.bestPerformance(category, size));
+        performanceLikeService.bestPerformance(genre, size));
   }
 
   // 찜 하기

--- a/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceLikeController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/controller/PerformanceLikeController.java
@@ -1,0 +1,73 @@
+package com.halfgallon.withcon.domain.performance.controller;
+
+import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
+import com.halfgallon.withcon.domain.performance.dto.response.MainPagePerformanceResponse;
+import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+import com.halfgallon.withcon.domain.performance.service.PerformanceLikeService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/performance")
+@RequiredArgsConstructor
+public class PerformanceLikeController {
+
+  private final PerformanceLikeService performanceLikeService;
+
+  // 장르별 찜 많은순 5개 조회
+  @GetMapping("/best")
+  public ResponseEntity<MainPagePerformanceResponse> bestPerformance(
+      @RequestParam String category,
+      @RequestParam int size) {
+
+    return ResponseEntity.ok(
+        performanceLikeService.bestPerformance(category, size));
+  }
+
+  // 찜 하기
+  @PutMapping("/{performanceId}/like")
+  public ResponseEntity<String> likePerformance(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable String performanceId) {
+
+    return ResponseEntity.ok(performanceLikeService.likePerformance(
+        customUserDetails.getId(), performanceId));
+  }
+
+  // 찜 해제
+  @PutMapping("/{performanceId}/unlike")
+  public ResponseEntity<String> unlikePerformance(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable String performanceId) {
+
+    return ResponseEntity.ok(performanceLikeService.unlikePerformance(
+        customUserDetails.getId(), performanceId));
+  }
+
+  @GetMapping("/favorite")
+  public ResponseEntity<List<PerformanceResponse>> findLikes(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+    return ResponseEntity.ok(
+        performanceLikeService.findLikes(customUserDetails.getId()));
+  }
+
+  // 나의 찜 공연 id 목록
+  @GetMapping("/favorite-id")
+  public ResponseEntity<List<String>> findLikesId(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+    return ResponseEntity.ok(
+        performanceLikeService.findLikesId(customUserDetails.getId()));
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/MainPagePerformanceResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/dto/response/MainPagePerformanceResponse.java
@@ -1,0 +1,15 @@
+package com.halfgallon.withcon.domain.performance.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MainPagePerformanceResponse {
+
+  private List<PerformanceResponse> performanceResponses;
+
+  private List<Integer> parts;
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/Performance.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/Performance.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -55,8 +56,8 @@ public class Performance extends BaseTimeEntity {
   @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<ChatRoom> chatRoom;
 
-  @OneToMany(mappedBy = "performance")
-  private List<PerformanceLike> performanceLikes;
+  @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default private List<PerformanceLike> performanceLikes = new ArrayList<>();
 
   @OneToOne(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
   private PerformanceDetail performanceDetail;
@@ -69,5 +70,13 @@ public class Performance extends BaseTimeEntity {
     this.poster = request.getPoster();
     this.facility = request.getFacility();
     this.status = request.getStatus();
+  }
+
+  public void addLikes() {
+    this.likes = this.likes + 1L;
+  }
+
+  public void subLikes() {
+    this.likes = this.likes -1L;
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/PerformanceLike.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/entitiy/PerformanceLike.java
@@ -7,8 +7,16 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PerformanceLike extends BaseTimeEntity {
 
   @Id
@@ -16,7 +24,7 @@ public class PerformanceLike extends BaseTimeEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id")
-  private Member Member;
+  private Member member;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "performance_id")

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/CustomPerformanceRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/CustomPerformanceRepository.java
@@ -1,10 +1,13 @@
 package com.halfgallon.withcon.domain.performance.repository;
 
+import com.halfgallon.withcon.domain.performance.constant.Genre;
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomPerformanceRepository {
+  List<Performance> findBestByPerformance(Genre genre, int size);
 
   Page<Performance> searchPerformance(String keyword, Pageable pageable);
 

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceLikeRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceLikeRepository.java
@@ -1,10 +1,21 @@
 package com.halfgallon.withcon.domain.performance.repository;
 
 import com.halfgallon.withcon.domain.performance.entitiy.PerformanceLike;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PerformanceLikeRepository extends JpaRepository<PerformanceLike, Long> {
+
+  boolean existsByMember_IdAndPerformance_Id(Long memberId, String performanceId);
+
+  Optional<PerformanceLike> findByMember_idAndPerformance_Id(
+      Long memberId, String performanceId);
+
+  void deleteByMember_IdAndPerformance_Id(Long memberId, String performanceId);
+
+  List<PerformanceLike> findPerformanceLikeByMember_Id(Long memberId);
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceLikeRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceLikeRepository.java
@@ -3,6 +3,8 @@ package com.halfgallon.withcon.domain.performance.repository;
 import com.halfgallon.withcon.domain.performance.entitiy.PerformanceLike;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,6 +17,9 @@ public interface PerformanceLikeRepository extends JpaRepository<PerformanceLike
       Long memberId, String performanceId);
 
   void deleteByMember_IdAndPerformance_Id(Long memberId, String performanceId);
+
+  Page<PerformanceLike> findPerformanceLikeByMember_Id(
+      Long memberId, Pageable pageable);
 
   List<PerformanceLike> findPerformanceLikeByMember_Id(Long memberId);
 

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/PerformanceRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PerformanceRepository extends JpaRepository<Performance, String>, CustomPerformanceRepository {
-
+public interface PerformanceRepository extends JpaRepository<Performance, String>,
+    CustomPerformanceRepository {
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/repository/impl/CustomPerformanceRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/repository/impl/CustomPerformanceRepositoryImpl.java
@@ -3,10 +3,12 @@ package com.halfgallon.withcon.domain.performance.repository.impl;
 import static com.halfgallon.withcon.domain.performance.entitiy.QPerformance.performance;
 import static com.halfgallon.withcon.domain.performance.entitiy.QPerformanceDetail.performanceDetail;
 
+import com.halfgallon.withcon.domain.performance.constant.Genre;
 import com.halfgallon.withcon.domain.performance.entitiy.Performance;
 import com.halfgallon.withcon.domain.performance.repository.CustomPerformanceRepository;
 import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -31,5 +33,15 @@ public class CustomPerformanceRepositoryImpl implements CustomPerformanceReposit
         .fetchResults();
 
     return new PageImpl<>(results.getResults(), pageable, results.getTotal());
+  }
+
+  public List<Performance> findBestByPerformance(Genre genre, int size) {
+    return jpaQueryFactory.select(performance)
+        .from(performanceDetail)
+        .join(performanceDetail.performance, performance)
+        .where(performanceDetail.genre.eq(genre))
+        .orderBy(performance.likes.desc())
+        .limit(size)
+        .fetch();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceLikeService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceLikeService.java
@@ -3,6 +3,8 @@ package com.halfgallon.withcon.domain.performance.service;
 import com.halfgallon.withcon.domain.performance.dto.response.MainPagePerformanceResponse;
 import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PerformanceLikeService {
 
@@ -11,8 +13,7 @@ public interface PerformanceLikeService {
   String likePerformance(Long memberId, String performanceId);
 
   String unlikePerformance(Long memberId, String performanceId);
-
-  List<PerformanceResponse> findLikes(Long memberId);
+  Page<PerformanceResponse> findLikes(Long memberId, Pageable pageable);
 
   List<String> findLikesId(Long memberId);
 

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceLikeService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceLikeService.java
@@ -1,0 +1,19 @@
+package com.halfgallon.withcon.domain.performance.service;
+
+import com.halfgallon.withcon.domain.performance.dto.response.MainPagePerformanceResponse;
+import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+import java.util.List;
+
+public interface PerformanceLikeService {
+
+  MainPagePerformanceResponse bestPerformance(String category, int size);
+
+  String likePerformance(Long memberId, String performanceId);
+
+  String unlikePerformance(Long memberId, String performanceId);
+
+  List<PerformanceResponse> findLikes(Long memberId);
+
+  List<String> findLikesId(Long memberId);
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceLikeService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/PerformanceLikeService.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface PerformanceLikeService {
 
-  MainPagePerformanceResponse bestPerformance(String category, int size);
+  MainPagePerformanceResponse bestPerformance(String genre, int size);
 
   String likePerformance(Long memberId, String performanceId);
 

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceLikeServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceLikeServiceImpl.java
@@ -35,15 +35,15 @@ public class PerformanceLikeServiceImpl implements PerformanceLikeService {
   // 장르별 베스트 5개씩 조회
   @Override
   @Transactional(readOnly = true)
-  public MainPagePerformanceResponse bestPerformance(String category, int size) {
-    String[] genres = category.split(",");
+  public MainPagePerformanceResponse bestPerformance(String genre, int size) {
+    String[] category = genre.split(",");
 
     List<Integer> parts = new ArrayList<>();
 
-    List<PerformanceResponse> responses = Arrays.stream(genres)
-        .flatMap(genre -> {
+    List<PerformanceResponse> responses = Arrays.stream(category)
+        .flatMap(value -> {
           List<Performance> performances = performanceRepository
-              .findBestByPerformance(Genre.valueOf(genre), size);
+              .findBestByPerformance(Genre.valueOf(value), size);
           parts.add(performances.size());
           return performances.stream();
         })

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceLikeServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceLikeServiceImpl.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,7 +43,7 @@ public class PerformanceLikeServiceImpl implements PerformanceLikeService {
     List<PerformanceResponse> responses = Arrays.stream(genres)
         .flatMap(genre -> {
           List<Performance> performances = performanceRepository
-              .findBestByPerformance(Genre.fromDescription(genre), size);
+              .findBestByPerformance(Genre.valueOf(genre), size);
           parts.add(performances.size());
           return performances.stream();
         })
@@ -112,14 +114,12 @@ public class PerformanceLikeServiceImpl implements PerformanceLikeService {
 
   // 나의 찜 공연 목록
   @Override
-  public List<PerformanceResponse> findLikes(Long memberId) {
-    List<PerformanceLike> performanceLikes = performanceLikeRepository.
-        findPerformanceLikeByMember_Id(memberId);
+  public Page<PerformanceResponse> findLikes(Long memberId, Pageable pageable) {
+    Page<PerformanceLike> performanceLikes = performanceLikeRepository.
+        findPerformanceLikeByMember_Id(memberId, pageable);
 
-    return performanceLikes.stream()
-        .map(PerformanceLike::getPerformance)
-        .map(PerformanceResponse::fromEntity)
-        .collect(Collectors.toList());
+    return performanceLikes.map(
+        performanceLike -> PerformanceResponse.fromEntity(performanceLike.getPerformance()));
   }
 
   // 나의 찜 공연Id 목록

--- a/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceLikeServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceLikeServiceImpl.java
@@ -1,0 +1,135 @@
+package com.halfgallon.withcon.domain.performance.service.impl;
+
+import com.halfgallon.withcon.domain.member.entity.Member;
+import com.halfgallon.withcon.domain.member.repository.MemberRepository;
+import com.halfgallon.withcon.domain.performance.constant.Genre;
+import com.halfgallon.withcon.domain.performance.dto.response.MainPagePerformanceResponse;
+import com.halfgallon.withcon.domain.performance.dto.response.PerformanceResponse;
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import com.halfgallon.withcon.domain.performance.entitiy.PerformanceLike;
+import com.halfgallon.withcon.domain.performance.repository.PerformanceLikeRepository;
+import com.halfgallon.withcon.domain.performance.repository.PerformanceRepository;
+import com.halfgallon.withcon.domain.performance.service.PerformanceLikeService;
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PerformanceLikeServiceImpl implements PerformanceLikeService {
+
+  private final PerformanceLikeRepository performanceLikeRepository;
+  private final MemberRepository memberRepository;
+  private final PerformanceRepository performanceRepository;
+
+  // 장르별 베스트 5개씩 조회
+  @Override
+  @Transactional(readOnly = true)
+  public MainPagePerformanceResponse bestPerformance(String category, int size) {
+    String[] genres = category.split(",");
+
+    List<Integer> parts = new ArrayList<>();
+
+    List<PerformanceResponse> responses = Arrays.stream(genres)
+        .flatMap(genre -> {
+          List<Performance> performances = performanceRepository
+              .findBestByPerformance(Genre.fromDescription(genre), size);
+          parts.add(performances.size());
+          return performances.stream();
+        })
+        .map(PerformanceResponse::fromEntity)
+        .toList();
+
+    return MainPagePerformanceResponse.builder()
+        .performanceResponses(responses)
+        .parts(parts)
+        .build();
+  }
+
+  // 찜 하기
+  @Override
+  @Transactional
+  public String likePerformance(Long memberId, String performanceId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    Performance performance = performanceRepository.findById(performanceId)
+        .orElseThrow(() -> new CustomException(ErrorCode.PERFORMANCE_NOT_FOUND));
+
+    boolean exist = performanceLikeRepository
+        .existsByMember_IdAndPerformance_Id(memberId, performanceId);
+
+    if(!exist) {
+      performance.addLikes();
+
+      PerformanceLike performanceLike = PerformanceLike.builder()
+          .member(member)
+          .performance(performance)
+          .build();
+      performanceLikeRepository.save(performanceLike);
+      log.info("Service : 공연 찜 성공");
+
+      performance.getPerformanceLikes().add(performanceLike);
+      member.getLikes().add(performanceLike);
+
+      return performanceId;
+    }
+    throw new CustomException(ErrorCode.ALREADY_LIKE_EXIST);
+  }
+
+  // 찜 해제
+  @Override
+  @Transactional
+  public String unlikePerformance(Long memberId, String performanceId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    Performance performance = performanceRepository.findById(performanceId)
+        .orElseThrow(() -> new CustomException(ErrorCode.PERFORMANCE_NOT_FOUND));
+
+    PerformanceLike performanceLike = performanceLikeRepository
+        .findByMember_idAndPerformance_Id(memberId, performanceId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_LIKE));
+
+    performance.subLikes();
+    log.info("Service : 공연 찜 해제");
+
+    performanceLikeRepository.deleteByMember_IdAndPerformance_Id(
+        memberId, performanceId);
+
+    performance.getPerformanceLikes().add(performanceLike);
+    member.getLikes().add(performanceLike);
+    return performanceId;
+  }
+
+  // 나의 찜 공연 목록
+  @Override
+  public List<PerformanceResponse> findLikes(Long memberId) {
+    List<PerformanceLike> performanceLikes = performanceLikeRepository.
+        findPerformanceLikeByMember_Id(memberId);
+
+    return performanceLikes.stream()
+        .map(PerformanceLike::getPerformance)
+        .map(PerformanceResponse::fromEntity)
+        .collect(Collectors.toList());
+  }
+
+  // 나의 찜 공연Id 목록
+  @Override
+  public List<String> findLikesId(Long memberId) {
+    List<PerformanceLike> performanceLikes = performanceLikeRepository.
+        findPerformanceLikeByMember_Id(memberId);
+
+    return performanceLikes.stream()
+        .map(performanceLike -> performanceLike.getPerformance().getId())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package com.halfgallon.withcon.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.CONTINUE;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
   CONTENT_TYPE_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Content-type 요청입니다."),
   LOGIN_FAILURE_MESSAGE(BAD_REQUEST.value(), "아이디 혹은 비밀번호가 올바르지 않습니다."),
   OAUTH2_LOGIN_FAILURE_MESSAGE(BAD_REQUEST.value(), "소셜 로그인에 실패하셨습니다."),
+  ALREADY_LIKE_EXIST(BAD_REQUEST.value(), "이미 찜한 공연입니다."),
+  NOT_EXIST_LIKE(BAD_REQUEST.value(), "찜이 존재하지 않습니다."),
 
   /**
    * 401 Unauthorized

--- a/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceLikeServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/performance/service/impl/PerformanceLikeServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.halfgallon.withcon.domain.performance.service.impl;
+
+import static org.mockito.BDDMockito.given;
+
+import com.halfgallon.withcon.domain.member.entity.Member;
+import com.halfgallon.withcon.domain.member.repository.MemberRepository;
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
+import com.halfgallon.withcon.domain.performance.entitiy.PerformanceLike;
+import com.halfgallon.withcon.domain.performance.repository.PerformanceLikeRepository;
+import com.halfgallon.withcon.domain.performance.repository.PerformanceRepository;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PerformanceLikeServiceImplTest {
+
+  @InjectMocks
+  private PerformanceLikeServiceImpl performanceLikeService;
+  @Mock
+  private PerformanceLikeRepository performanceLikeRepository;
+  @Mock
+  private MemberRepository memberRepository;
+  @Mock
+  private PerformanceRepository performanceRepository;
+
+  @Test
+  @DisplayName("찜 성공")
+  void success_like_performance() {
+    //given
+    Member member = Member.builder()
+        .id(1L)
+        .likes(new ArrayList<>())
+        .build();
+
+    Long memberId = 1L;
+
+    given(memberRepository.findById(memberId))
+        .willReturn(Optional.of(member));
+
+    Performance performance = Performance.builder()
+        .id("FF1")
+        .likes(5L)
+        .performanceLikes(new ArrayList<>())
+        .build();
+
+    String performanceId = "FF1";
+
+    given(performanceRepository.findById(performanceId))
+        .willReturn(Optional.of(performance));
+
+    given(performanceLikeRepository.existsByMember_IdAndPerformance_Id(memberId, performanceId))
+        .willReturn(false);
+    
+    PerformanceLike performanceLike = PerformanceLike.builder()
+        .id(3L)
+        .member(member)
+        .performance(performance)
+        .build();
+
+    member.getLikes().add(performanceLike);
+    performance.getPerformanceLikes().add(performanceLike);
+
+    //when
+    String perId = performanceLikeService.likePerformance(memberId, performanceId);
+    //then
+
+    Assertions.assertThat(member.getLikes().get(0)).
+        isEqualTo(performanceLike);
+    Assertions.assertThat(performance.getPerformanceLikes().get(0)).
+        isEqualTo(performanceLike);
+    Assertions.assertThat(performance.getLikes()).isEqualTo(6L);
+    Assertions.assertThat(perId).isEqualTo(performanceId);
+  }
+
+  @Test
+  @DisplayName("찜 취소 성공")
+  void success_unlike_performance() {
+    //given
+    Member member = Member.builder()
+        .id(1L)
+        .likes(new ArrayList<>())
+        .build();
+
+    Long memberId = 1L;
+
+    given(memberRepository.findById(memberId))
+        .willReturn(Optional.of(member));
+
+    Performance performance = Performance.builder()
+        .id("FF1")
+        .likes(5L)
+        .performanceLikes(new ArrayList<>())
+        .build();
+
+    String performanceId = "FF1";
+
+    given(performanceRepository.findById(performanceId))
+        .willReturn(Optional.of(performance));
+
+    PerformanceLike performanceLike = PerformanceLike.builder()
+        .id(3L)
+        .member(member)
+        .performance(performance)
+        .build();
+
+    given(performanceLikeRepository.findByMember_idAndPerformance_Id(
+        memberId, performanceId))
+        .willReturn(Optional.of(performanceLike));
+
+    member.getLikes().add(performanceLike);
+    performance.getPerformanceLikes().add(performanceLike);
+
+    //when
+    String perId = performanceLikeService.unlikePerformance(memberId, performanceId);
+    //then
+
+    Assertions.assertThat(member.getLikes().get(0)).
+        isEqualTo(performanceLike);
+    Assertions.assertThat(performance.getPerformanceLikes().get(0)).
+        isEqualTo(performanceLike);
+    Assertions.assertThat(performance.getLikes()).isEqualTo(4L);
+    Assertions.assertThat(perId).isEqualTo(performanceId);
+  }
+}


### PR DESCRIPTION
## 📝작업 내용

- 메인페이지에서 장르별 공연 목록 조회( 찜많은 순으로 5개씩)
- 공연 찜 하기 기능
- 공연 찜 취소 기능
- 내가 찜한 공연 목록 조회 기능
- 내가 찜한 공연Id 목록 조회 기능

작업내용

## 💬리뷰 참고사항

<메인페이지 공연 조회>
- 메인페이지 공연 목록 요청을 각 카테고리를 ,로 합친 문자열로 받고 개수를 받습니다.  ex) "콘서트,뮤지컬,연극" / 5
  콤마로 split을 해서 카테고리를 추출하고,  PerformanceDetail과 Performance DB를 조인해서 카테고리 별로 찜이 많은순을 5개씩   
  조회해서 가져옵니다. 이때 카테고리별로 parts라는 List에 해당 카테고리에서 가져온 데이터 개수를 저장합니다.
  이후에 응답으로 List에 Performance를 모두 담아 보내고, Parts List로 카테고리별로 데이터를 구분할 수 있게 보내줍니다. 

<찜 하기>
- 찜이 이미 되있는지 확인 후 없다면 추가합니다. 그리고 공연의 찜 개수를 하나 더해줍니다. 이때 찜 데이터를 공연과 회원의 관계형 필드에 추가로 저장해줍니다. 
- 있으면 현재 예외를 던지지만, 찜 기능에 예외가 필요한가 싶어서 프론트분들과 회의 후 진행하려고 합니다.

<찜 취소>
- 찜이 이미 있다면 데이터를 지웁니다. 그리고 공연의 찜개수를 하나 빼줍니다. 이때 찜 데이터를 공연과 회원의 관계형 필드에 추가로 저장해줍니다.
- 찜이 없다면 예외를 던지게 됩니다. 역시 회의 후 고려합니다.

<나의 찜 공연/공연ID 목록 조회>
- 찜 테이블에서 memberId로 조회해서 각각 Performance외래키와 연결된 엔티티를 리스트에 담아 반환합니다.  이때 공연ID의 경우 따로 추출해서 List에 담아 보내줍니다. 
 

참고사항

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

(close) #80