### PR TITLE
[refactor] 채팅 메시지 리팩토링

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatMessageController.java
@@ -6,7 +6,6 @@ import com.halfgallon.withcon.domain.chat.constant.ChattingConstant;
 import com.halfgallon.withcon.domain.chat.dto.ChatMessageDto;
 import com.halfgallon.withcon.domain.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -14,7 +13,6 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ChatMessageController {
@@ -50,7 +48,6 @@ public class ChatMessageController {
   @RabbitListener(queues = ChattingConstant.CHAT_QUEUE_NAME)
   public void receive(ChatMessageDto response) {
     chatMessageService.saveChatMessage(response);
-    log.info("ChatMessageDto.getMessage() : {}", response.getMessage());
   }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageDto.java
@@ -1,9 +1,7 @@
 package com.halfgallon.withcon.domain.chat.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.halfgallon.withcon.domain.chat.constant.MessageType;
 import com.halfgallon.withcon.domain.chat.entity.ChatMessage;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,8 +19,7 @@ public class ChatMessageDto {
   private String message;
   private MessageType messageType;
 
-  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-  private LocalDateTime sendAt;
+  private Long sendAt;
 
   public ChatMessage toEntity() {
     return ChatMessage.builder()

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatMessage.java
@@ -11,13 +11,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Getter
@@ -43,9 +41,8 @@ public class ChatMessage {
   @Enumerated(value = EnumType.STRING)
   private MessageType messageType;
 
-  @CreatedDate
-  @Column(updatable = false)
-  private LocalDateTime sendAt;
+  @Column(nullable = false)
+  private Long sendAt;
 
   public void updateChatRoom(ChatRoom chatRoom) {
     this.room = chatRoom;


### PR DESCRIPTION
## 📝작업 내용

1. 채팅 메시지 time 타입 변경 - 채팅 메시지 발송하는 시간 변경(`LocalDateTime` -> `Long`)

2. 채팅 저장 시퀀스 변경
   - 기존 메시지 발송 시에 쿼리문 조회 시 null 인 경우, exception로 반환되었지만
채팅메시지를 저장할 시에는 해당 채팅방 참여자가 아닌 경우는 발생하지 않는다는 
조건이기 때문에 `optional.empty` 반환 시에는 저장하지 않는 시퀀스로 변경

## 💬리뷰 참고사항

- [x] API 테스트(채팅 메시지 발송 API)

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/d603553d-f89e-4197-8caa-b9553b113964)


## #️⃣연관된 이슈

close #95 
