### PR TITLE
[fix] 필터 내 예외처리를 위한 ExceptionHandlingFilter 추가

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.halfgallon.withcon.domain.auth.client.OAuth2Client;
 import com.halfgallon.withcon.domain.auth.manager.JwtManager;
 import com.halfgallon.withcon.domain.auth.repository.AccessTokenRepository;
 import com.halfgallon.withcon.domain.auth.repository.RefreshTokenRepository;
+import com.halfgallon.withcon.domain.auth.security.filter.ExceptionHandlingFilter;
 import com.halfgallon.withcon.domain.auth.security.filter.JwtAuthenticationFilter;
 import com.halfgallon.withcon.domain.auth.security.filter.LoginFilter;
 import com.halfgallon.withcon.domain.auth.security.filter.OAuth2LoginFilter;
@@ -89,6 +90,7 @@ public class SecurityConfig {
         )
         .addFilterBefore(new JwtAuthenticationFilter(memberRepository, accessTokenRepository),
             LogoutFilter.class)
+        .addFilterBefore(new ExceptionHandlingFilter(objectMapper), JwtAuthenticationFilter.class)
         .addFilterBefore(loginFilter(), UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(oAuth2LoginFilter(), UsernamePasswordAuthenticationFilter.class)
     ;

--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/filter/ExceptionHandlingFilter.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/filter/ExceptionHandlingFilter.java
@@ -1,0 +1,36 @@
+package com.halfgallon.withcon.domain.auth.security.filter;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class ExceptionHandlingFilter extends OncePerRequestFilter {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    try {
+      filterChain.doFilter(request, response);
+    } catch (CustomException e) {
+      ErrorResponse errorResponse = new ErrorResponse(
+          e.getErrorCode().getStatus(), e.getErrorCode(), e.getMessage());
+
+      objectMapper.writeValue(response.getOutputStream(), errorResponse);
+      response.setStatus(UNAUTHORIZED.value());
+      response.setContentType(APPLICATION_JSON_VALUE);
+    }
+  }
+}


### PR DESCRIPTION
## 📝작업 내용

Servlet 필터는 DispatcherServlet이 동작하기 전에 처리되므로 스프링 컨텍스트의 범위를 벗어납니다. 따라서 직접 정의한 GlobalExceptionHandler에 의해 처리될 수 없었습니다. 따라서 JwtAuthenticationFilter 에서 액세스토큰 만료 예외 발생 시 status가 401이 아닌 500으로 처리되었습니다. JwtAuthenticationFilter 앞에 ExceptionHandlingFilter 를 새로 둠으로써 예외를 처리하였습니다.

![스크린샷 2024-02-17 03 21 44](https://github.com/HalfGallonTeam/WithCon_BE/assets/68311264/0c0bd2c2-d8f9-4e3a-9fbb-1181e68c5f2d)
![스크린샷 2024-02-17 03 21 55](https://github.com/HalfGallonTeam/WithCon_BE/assets/68311264/374066d0-950a-45e4-b7f2-ab942d6747ed)


- [x] API 테스트

## 💬리뷰 참고사항

## #️⃣연관된 이슈
