### PR TITLE
[feat] 엘라스틱서치 공연 아이디 추가

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
@@ -38,8 +38,10 @@ public class TagController {
    * 태그 검색(ElasticSearch)
    */
   @GetMapping("/search")
-  public ResponseEntity<?> findTagKeyword(@RequestParam("keyword") String keyword) {
-    return ResponseEntity.ok(tagService.findTagKeyword(keyword));
+  public ResponseEntity<?> findTagKeyword(
+      @RequestParam("performance") String performanceId,
+      @RequestParam("keyword") String keyword) {
+    return ResponseEntity.ok(tagService.findTagKeyword(performanceId, keyword));
   }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/dto/TagSearchDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/dto/TagSearchDto.java
@@ -5,11 +5,13 @@ import lombok.Builder;
 
 @Builder
 public record TagSearchDto(
+    String performanceId,
     String tagName,
     Integer count
 ) {
   public static TagSearchDto fromEntity(TagSearch tagSearch) {
     return TagSearchDto.builder()
+        .performanceId(tagSearch.getPerformanceId())
         .tagName(tagSearch.getName())
         .count(tagSearch.getTagCount())
         .build();

--- a/src/main/java/com/halfgallon/withcon/domain/tag/entity/Tag.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/entity/Tag.java
@@ -1,6 +1,7 @@
 package com.halfgallon.withcon.domain.tag.entity;
 
 import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -29,7 +30,10 @@ public class Tag {
   @JoinColumn(name = "chatRoom_id")
   private ChatRoom chatRoom;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "performance_id")
+  private Performance performance;
+
   @Column(nullable = false)
   private String name;
-
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/entity/TagSearch.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/entity/TagSearch.java
@@ -27,10 +27,6 @@ public class TagSearch {
   @Field(type = FieldType.Integer, name = "tag_count")
   private Integer tagCount;
 
-  public static TagSearch fromEntity(Tag tag) {
-    return TagSearch.builder()
-        .id(tag.getId().toString())
-        .name(tag.getName())
-        .build();
-  }
+  @Field(type = FieldType.Text, name = "performance_id")
+  private String performanceId;
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/CustomTagSearchRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/CustomTagSearchRepository.java
@@ -1,5 +1,11 @@
 package com.halfgallon.withcon.domain.tag.repository;
 
+import com.halfgallon.withcon.domain.tag.entity.TagSearch;
+import java.util.List;
+
 public interface CustomTagSearchRepository {
-  void updateTagCount(String id, String name, Integer tagCount);
+  void updateSearchTag(TagSearch tagSearch, Integer tagCount);
+
+  List<TagSearch> findTagAutoComplete(String performanceId, String name);
+
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagRepository.java
@@ -6,6 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long>, CustomTagRepository {
-
-  Integer countTagByName(String name);
+  Integer countTagByNameAndPerformance_Id(String name, String performanceId);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagSearchRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagSearchRepository.java
@@ -1,9 +1,7 @@
 package com.halfgallon.withcon.domain.tag.repository;
 
 import com.halfgallon.withcon.domain.tag.entity.TagSearch;
-import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagSearchRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/TagSearchRepository.java
@@ -10,9 +10,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TagSearchRepository extends ElasticsearchRepository<TagSearch, String>,
     CustomTagSearchRepository {
-
-  List<TagSearch> findAllByNameStartingWithIgnoreCase(String name, Pageable pageable);
-
-  Optional<TagSearch> findByName(String name);
-
+  Optional<TagSearch> findByNameAndPerformanceId(String name, String PerformanceId);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagSearchRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagSearchRepositoryImpl.java
@@ -2,10 +2,15 @@ package com.halfgallon.withcon.domain.tag.repository.impl;
 
 import com.halfgallon.withcon.domain.tag.entity.TagSearch;
 import com.halfgallon.withcon.domain.tag.repository.CustomTagSearchRepository;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 
 @RequiredArgsConstructor
@@ -25,5 +30,19 @@ public class CustomTagSearchRepositoryImpl implements CustomTagSearchRepository 
 
     operations.update(updateQuery, operations.getIndexCoordinatesFor(TagSearch.class));
   }
+
+  @Override
+  public List<TagSearch> findTagAutoComplete(String performanceId, String name) {
+    CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+    criteriaQuery.addCriteria(Criteria.where("performance_id").is(performanceId));
+    criteriaQuery.addCriteria(Criteria.where("name").startsWith(name));
+
+    Sort sort = Sort.by(Sort.Order.desc("tag_count"));
+    criteriaQuery.addSort(sort);
+
+    SearchHits<TagSearch> hits = operations.search(criteriaQuery, TagSearch.class);
+    return hits.stream().map(SearchHit::getContent).limit(10).toList();
+  }
+
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagSearchRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagSearchRepositoryImpl.java
@@ -14,12 +14,13 @@ public class CustomTagSearchRepositoryImpl implements CustomTagSearchRepository 
   private final ElasticsearchOperations operations;
 
   @Override
-  public void updateTagCount(String id, String name, Integer tagCount) {
-    Map<String, Object> map = Map.of("name", name, "tag_count", tagCount);
-    Document document = operations.getElasticsearchConverter().mapObject(map);
+  public void updateSearchTag(TagSearch tagSearch, Integer tagCount) {
+    Map<String, Object> map = Map.of("name", tagSearch.getName(),
+        "performance_id", tagSearch.getPerformanceId(),
+        "tag_count", tagCount);
 
-    UpdateQuery updateQuery = UpdateQuery.builder(id)
-        .withDocument(document)
+    UpdateQuery updateQuery = UpdateQuery.builder(tagSearch.getId())
+        .withDocument(operations.getElasticsearchConverter().mapObject(map))
         .build();
 
     operations.update(updateQuery, operations.getIndexCoordinatesFor(TagSearch.class));

--- a/src/main/java/com/halfgallon/withcon/domain/tag/service/TagService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/service/TagService.java
@@ -10,5 +10,5 @@ public interface TagService {
 
   List<TagCountDto> findTagNameOrderByCount(String tagName);
 
-  List<TagSearchDto> findTagKeyword(String keyword);
+  List<TagSearchDto> findTagKeyword(String performanceId, String keyword);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/service/TagServiceImpl.java
@@ -7,10 +7,6 @@ import com.halfgallon.withcon.domain.tag.repository.TagRepository;
 import com.halfgallon.withcon.domain.tag.repository.TagSearchRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,11 +31,9 @@ public class TagServiceImpl implements TagService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<TagSearchDto> findTagKeyword(String keyword) {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Direction.DESC, "id"));
-
-    List<TagSearch> tagSearches = tagSearchRepository.findAllByNameStartingWithIgnoreCase(keyword, pageable);
-    return tagSearches.stream().map(TagSearchDto::fromEntity).toList();
+  public List<TagSearchDto> findTagKeyword(String performanceId, String keyword) {
+    List<TagSearch> searches = tagSearchRepository.findTagAutoComplete(performanceId, keyword);
+    return searches.stream().map(TagSearchDto::fromEntity).toList();
   }
 
 }

--- a/src/main/resources/static/elastic/tag-mappings.json
+++ b/src/main/resources/static/elastic/tag-mappings.json
@@ -9,6 +9,9 @@
     },
     "tag_count": {
       "type": "integer"
+    },
+    "performance_id": {
+      "type": "keyword"
     }
   }
 }

--- a/src/test/http/tag.http
+++ b/src/test/http/tag.http
@@ -9,3 +9,10 @@ Content-Type: application/json
 %}
 GET http://localhost:8080/tag/{{tags}}/search
 Content-Type: application/json
+
+### 태그 자동완성
+< {%
+  request.variables.set("keyword", "수")
+%}
+GET http://localhost:8080/tag/search?performance=1&keyword={{keyword}}
+Content-Type: application/json


### PR DESCRIPTION
## 📝작업 내용
엘라스틱서치 공연 정보 추가
 - ElasticSearch 도큐먼트 및 JSON 공연 아이디 추가
 - Tag Entity 공연 매핑 추가 
 - TagSearchDto에 `performanceId` 추가
 - ElasticSearch 저장 시에 공연 아이디 정보 추가
 - ElasticSearch 데이터 업데이트 시에 태그 정보의 공연아이디를 확인 후 진행
 - 태그 정보에 공연아이디도 함께 확인해서 공연에 따른 태그 정보를 추출

엘라스틱서치 공연 정보 추가
 - ElasticSearch 도큐먼트 및 JSON 공연 아이디 추가
 - Tag Entity 공연 매핑 추가 
 - TagSearchDto에 `performanceId` 추가

## 💬리뷰 참고사항

- [x] API 테스트

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/cd4c28e9-6436-49b4-a90f-b0a261e1b878)

## #️⃣연관된 이슈

close #106
