### PR TITLE
[feat] 현재 비밀번호 확인 API 추가 및 비밀번호 재설정 기능 추가

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/auth/security/filter/ExceptionHandlingFilter.java
+++ b/src/main/java/com/halfgallon/withcon/domain/auth/security/filter/ExceptionHandlingFilter.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
@@ -25,6 +26,7 @@ public class ExceptionHandlingFilter extends OncePerRequestFilter {
     try {
       filterChain.doFilter(request, response);
     } catch (CustomException e) {
+
       ErrorResponse errorResponse = new ErrorResponse(
           e.getErrorCode().getStatus(), e.getErrorCode(), e.getMessage());
 

--- a/src/main/java/com/halfgallon/withcon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.halfgallon.withcon.domain.member.controller;
 
 import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
+import com.halfgallon.withcon.domain.member.dto.request.CurrentPasswordCheckRequest;
 import com.halfgallon.withcon.domain.member.dto.request.UpdateMemberRequest;
 import com.halfgallon.withcon.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,14 @@ public class MemberController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestBody UpdateMemberRequest updateMemberRequest) {
     memberService.updateMember(userDetails.getId(), updateMemberRequest);
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/current-password-check")
+  public ResponseEntity<Void> currentPasswordCheck(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestBody CurrentPasswordCheckRequest request) {
+    memberService.currentPasswordCheck(userDetails.getId(), request.password());
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/halfgallon/withcon/domain/member/dto/request/CurrentPasswordCheckRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/dto/request/CurrentPasswordCheckRequest.java
@@ -1,0 +1,5 @@
+package com.halfgallon.withcon.domain.member.dto.request;
+
+public record CurrentPasswordCheckRequest(String password) {
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/member/dto/request/UpdateMemberRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/dto/request/UpdateMemberRequest.java
@@ -2,7 +2,8 @@ package com.halfgallon.withcon.domain.member.dto.request;
 
 public record UpdateMemberRequest(
     String nickname,
-    String phoneNumber
+    String phoneNumber,
+    String newPassword
 ) {
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/entity/Member.java
@@ -60,6 +60,10 @@ public class Member extends BaseTimeEntity {
     this.phoneNumber = request.phoneNumber();
   }
 
+  public void updatePassword(String encodedNewPassword) {
+    this.password = encodedNewPassword;
+  }
+
   public void updateProfileImage(String profileImageUrl) {
     this.profileImage = profileImageUrl;
   }

--- a/src/main/java/com/halfgallon/withcon/domain/member/service/MemberService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/service/MemberService.java
@@ -17,6 +17,11 @@ public interface MemberService {
   void updateMember(Long memberId, UpdateMemberRequest request);
 
   /**
+   * 현재 비밀번호 일치 확인
+   */
+  void currentPasswordCheck(Long memberId, String password);
+
+  /**
    * 회원 프로필 사진 업로드
    */
   void uploadProfileImage(Long memberId, MultipartFile image);
@@ -25,6 +30,5 @@ public interface MemberService {
    * 회원 탈퇴
    */
   void deleteMember(Long memberId);
-
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/member/service/impl/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.member.service.impl;
 
+import static com.halfgallon.withcon.global.exception.ErrorCode.CURRENT_PASSWORD_MISMATCH;
 import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.halfgallon.withcon.domain.member.dto.request.UpdateMemberRequest;
@@ -10,8 +11,10 @@ import com.halfgallon.withcon.domain.member.service.MemberService;
 import com.halfgallon.withcon.global.exception.CustomException;
 import com.halfgallon.withcon.global.storage.service.StorageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -19,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberServiceImpl implements MemberService {
 
   private final MemberRepository memberRepository;
+  private final PasswordEncoder passwordEncoder;
   private final StorageService storageService;
 
   @Override
@@ -32,6 +36,21 @@ public class MemberServiceImpl implements MemberService {
   public void updateMember(Long memberId, UpdateMemberRequest request) {
     Member findMember = findMemberOrThrow(memberId);
     findMember.update(request);
+
+    String newPassword = request.newPassword();
+    if (StringUtils.hasText(newPassword)) {
+      findMember.updatePassword(passwordEncoder.encode(newPassword));
+    }
+  }
+
+  @Override
+  public void currentPasswordCheck(Long memberId, String password) {
+    Member findMember = findMemberOrThrow(memberId);
+    boolean isMatches = passwordEncoder.matches(password, findMember.getPassword());
+
+    if (!isMatches) {
+      throw new CustomException(CURRENT_PASSWORD_MISMATCH);
+    }
   }
 
   @Override

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
   CONTENT_TYPE_NOT_SUPPORTED(BAD_REQUEST.value(), "잘못된 Content-type 요청입니다."),
   LOGIN_FAILURE_MESSAGE(BAD_REQUEST.value(), "아이디 혹은 비밀번호가 올바르지 않습니다."),
   OAUTH2_LOGIN_FAILURE_MESSAGE(BAD_REQUEST.value(), "소셜 로그인에 실패하셨습니다."),
+  CURRENT_PASSWORD_MISMATCH(BAD_REQUEST.value(), "현재 비밀번호와 일치하지 않습니다."),
 
   /**
    * 401 Unauthorized

--- a/src/test/java/com/halfgallon/withcon/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/auth/service/AuthServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.halfgallon.withcon.domain.auth.dto.request.AuthJoinRequest;
 import com.halfgallon.withcon.domain.auth.entity.RefreshToken;
 import com.halfgallon.withcon.domain.auth.manager.JwtManager;
+import com.halfgallon.withcon.domain.auth.repository.AccessTokenRepository;
 import com.halfgallon.withcon.domain.auth.repository.RefreshTokenRepository;
 import com.halfgallon.withcon.domain.member.entity.Member;
 import com.halfgallon.withcon.domain.member.repository.MemberRepository;
@@ -47,6 +48,9 @@ class AuthServiceImplTest {
 
   @Mock
   private RefreshTokenRepository refreshTokenRepository;
+
+  @Mock
+  private AccessTokenRepository accessTokenRepository;
 
   @Captor
   private ArgumentCaptor<Member> memberCaptor;

--- a/src/test/java/com/halfgallon/withcon/domain/member/service/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/member/service/impl/MemberServiceImplTest.java
@@ -1,10 +1,13 @@
 package com.halfgallon.withcon.domain.member.service.impl;
 
 import static com.halfgallon.withcon.domain.member.constant.LoginType.HOME;
+import static com.halfgallon.withcon.global.exception.ErrorCode.CURRENT_PASSWORD_MISMATCH;
 import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
 import com.halfgallon.withcon.domain.member.dto.request.UpdateMemberRequest;
@@ -19,12 +22,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceImplTest {
 
   @Mock
   private MemberRepository memberRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
 
   @InjectMocks
   private MemberServiceImpl memberService;
@@ -78,7 +85,7 @@ class MemberServiceImplTest {
     Long memberId = 1L;
 
     UpdateMemberRequest request =
-        new UpdateMemberRequest("변경위드콘", "010-9876-5432");
+        new UpdateMemberRequest("변경위드콘", "010-9876-5432", "newPassword1!");
 
     given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
@@ -96,7 +103,7 @@ class MemberServiceImplTest {
     Long memberId = 1L;
 
     UpdateMemberRequest request =
-        new UpdateMemberRequest("변경위드콘", "010-9876-5432");
+        new UpdateMemberRequest("변경위드콘", "010-9876-5432", null);
 
     Member findMember = Member.builder()
         .id(memberId)
@@ -113,6 +120,82 @@ class MemberServiceImplTest {
     // then
     assertThat(findMember.getNickname()).isEqualTo("변경위드콘");
     assertThat(findMember.getPhoneNumber()).isEqualTo("010-9876-5432");
+  }
+
+  @Test
+  @DisplayName("내 정보 변경 성공 - 비밀번호 재설정 포함")
+  void updateMember_And_updatePassword_Success() {
+    // given
+    Long memberId = 1L;
+
+    UpdateMemberRequest request =
+        new UpdateMemberRequest("변경위드콘", "010-9876-5432", "newPassword1!");
+
+    Member findMember = Member.builder()
+        .id(memberId)
+        .nickname("위드콘")
+        .phoneNumber("010-1234-5678")
+        .loginType(HOME)
+        .build();
+
+    given(memberRepository.findById(memberId)).willReturn(Optional.of(findMember));
+
+    // when
+    memberService.updateMember(memberId, request);
+
+    // then
+    assertThat(findMember.getNickname()).isEqualTo("변경위드콘");
+    assertThat(findMember.getPhoneNumber()).isEqualTo("010-9876-5432");
+    assertThat(findMember.getPassword()).isEqualTo(passwordEncoder.encode("newPassword1!"));
+  }
+
+  @Test
+  @DisplayName("현재 비밀번호 일치 확인 성공")
+  void currentPasswordCheck_Success() {
+    // given
+    Long memberId = 1L;
+    String password = "1q2w3e4r!";
+
+    Member findMember = Member.builder()
+        .id(memberId)
+        .nickname("위드콘")
+        .password(passwordEncoder.encode("1q2w3e4r!"))
+        .phoneNumber("010-1234-5678")
+        .loginType(HOME)
+        .build();
+
+    given(memberRepository.findById(memberId)).willReturn(Optional.of(findMember));
+    given(passwordEncoder.matches(password, findMember.getPassword())).willReturn(true);
+
+    // when
+    // then
+    assertThatNoException().isThrownBy(
+        () -> memberService.currentPasswordCheck(memberId, password));
+  }
+
+  @Test
+  @DisplayName("❗️현재 비밀번호 일치 확인 실패")
+  void currentPasswordCheck_Fail() {
+    // given
+    Long memberId = 1L;
+    String password = "no-matches-password!";
+
+    Member findMember = Member.builder()
+        .id(memberId)
+        .nickname("위드콘")
+        .password(passwordEncoder.encode("1q2w3e4r!"))
+        .phoneNumber("010-1234-5678")
+        .loginType(HOME)
+        .build();
+
+    given(memberRepository.findById(memberId)).willReturn(Optional.of(findMember));
+    given(passwordEncoder.matches(password, findMember.getPassword())).willReturn(false);
+
+    // when
+    // then
+    assertThatThrownBy(() -> memberService.currentPasswordCheck(memberId, password))
+        .isInstanceOf(CustomException.class)
+        .hasMessageContaining(CURRENT_PASSWORD_MISMATCH.getDescription());
   }
 
   @Test


### PR DESCRIPTION
## 📝작업 내용

회원이 정보를 수정하기 위한 폼으로 이동하기 위해서는 '현재 비밀번호 확인' 과 같은 검증이 필요합니다.

'현재 비밀번호 확인' API를 추가하였습니다.

비밀번호 재설정 기능을 추가하였습니다.

## 💬리뷰 참고사항

## #️⃣연관된 이슈

(close) #112 
