### PR TITLE
[feat] 태그 검색을 이용한 채팅방 목록 조회

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomController.java
@@ -72,4 +72,13 @@ public class ChatRoomController {
     return ResponseEntity.ok(
         chatRoomService.findAllMessageChatRoom(customUserDetails, chatMessageRequest, chatRoomId));
   }
+
+  @GetMapping("/chatRoom/performance/{performanceId}/tag/{tagName}")
+  public ResponseEntity<Page<ChatRoomResponse>> searchTagChatRoom(
+      @PathVariable("performanceId") String performanceId,
+      @PathVariable("tagName") String tag,
+      @PageableDefault(size = 5, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+    return ResponseEntity.ok(chatRoomService.findAllTagNameChatRoom(performanceId, tag, pageable));
+  }
+
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatParticipant.java
@@ -2,7 +2,6 @@ package com.halfgallon.withcon.domain.chat.entity;
 
 import com.halfgallon.withcon.domain.member.entity.Member;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,11 +24,11 @@ public class ChatParticipant {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne
   @JoinColumn(name = "member_id")
   private Member member;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne
   @JoinColumn(name = "chatRoom_id")
   private ChatRoom chatRoom;
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatParticipantRepository.java
@@ -13,4 +13,6 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
   List<ChatParticipant> findAllByChatRoom_Id(Long chatRoomId);
 
+  Optional<ChatParticipant> findByMember_Id(Long memberId);
+
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatRoomRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, CustomChatRoomRepository {
   boolean existsByName(String name);
 
   Page<ChatRoom> findAllByPerformance_Id(String performanceId, Pageable pageable);

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatRoomRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatRoomRepository.java
@@ -1,0 +1,11 @@
+package com.halfgallon.withcon.domain.chat.repository;
+
+import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomChatRoomRepository {
+
+  Page<ChatRoom> findAllTagNameChatRoom(String performanceId, String tagName, Pageable pageable);
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatRoomRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatRoomRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.halfgallon.withcon.domain.chat.repository.impl;
+
+import static com.halfgallon.withcon.domain.chat.entity.QChatRoom.chatRoom;
+import static com.halfgallon.withcon.domain.tag.entity.QTag.tag;
+
+import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import com.halfgallon.withcon.domain.chat.repository.CustomChatRoomRepository;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class CustomChatRoomRepositoryImpl implements CustomChatRoomRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+
+  @Override
+  public Page<ChatRoom> findAllTagNameChatRoom(String performanceId, String tagName,
+      Pageable pageable) {
+
+    List<ChatRoom> fetch = jpaQueryFactory.selectFrom(chatRoom)
+        .leftJoin(chatRoom.tags, tag)
+        .where(
+            chatRoom.performance.id.eq(performanceId),
+            tag.name.startsWithIgnoreCase(tagName)
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+
+    JPAQuery<Long> countQuery = jpaQueryFactory.select(chatRoom.count())
+        .from(chatRoom)
+        .leftJoin(chatRoom.tags, tag)
+        .where(chatRoom.performance.id.eq(performanceId), tag.name.startsWithIgnoreCase(tagName));
+
+    return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatRoomService.java
@@ -24,4 +24,6 @@ public interface ChatRoomService {
 
   Slice<ChatMessageDto> findAllMessageChatRoom(CustomUserDetails customUserDetails, ChatMessageRequest request,
       Long chatRoomId);
+
+  Page<ChatRoomResponse> findAllTagNameChatRoom(String performanceId, String tagName, Pageable pageable);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatMessageServiceImpl.java
@@ -35,7 +35,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
   @Override
   public ChatMessageDto enterMessage(ChatMessageDto request, Long roomId) {
-    ChatParticipant chatParticipant = participantRepository.findById(request.getMemberId())
+    ChatParticipant chatParticipant = participantRepository.findByMember_Id(request.getMemberId())
         .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
     String message = chatParticipant.getMember().getNickname() + "님이 입장하였습니다.";
@@ -51,7 +51,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
   @Override
   public ChatMessageDto exitMessage(ChatMessageDto request, Long roomId) {
-    ChatParticipant chatParticipant = participantRepository.findById(request.getMemberId())
+    ChatParticipant chatParticipant = participantRepository.findByMember_Id(request.getMemberId())
         .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
     String message = chatParticipant.getMember().getNickname() + "님이 퇴장하였습니다.";
@@ -67,7 +67,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
   @Override
   public ChatMessageDto kickMessage(ChatMessageDto request, Long roomId) {
-    ChatParticipant chatParticipant = participantRepository.findById(request.getMemberId())
+    ChatParticipant chatParticipant = participantRepository.findByMember_Id(request.getMemberId())
         .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
     String message = chatParticipant.getMember().getNickname() + "님이 강퇴당했습니다.";

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -33,6 +33,7 @@ import com.halfgallon.withcon.domain.tag.repository.TagSearchRepository;
 import com.halfgallon.withcon.global.exception.CustomException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -40,6 +41,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatRoomServiceImpl implements ChatRoomService {
@@ -66,6 +68,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         .orElseThrow(() -> new CustomException(PERFORMANCE_NOT_FOUND));
 
     chatRoom.updatePerformance(performance);
+    log.info("공연 정보 설정 완료");
 
     //채팅방 참여 인원 저장
     chatRoom.addChatParticipant(participantRepository.save(
@@ -73,6 +76,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             .chatRoom(chatRoom)
             .member(member)
             .build()));
+
+    log.info("채팅방 참여자 정보 설정 완료");
 
     //태그가 있는 경우에만 - 해당 태그 저장
     if (!CollectionUtils.isEmpty(request.tags())) {
@@ -94,6 +99,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
       //태그 기록(ElasticSearch 저장)
       upsertTagSearch(tagList);
     }
+
+    log.info("채팅방 태그 정보 설정 완료");
 
     return ChatRoomResponse.fromEntity(chatRoom);
   }
@@ -200,6 +207,13 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         request.lastMsgId(), chatRoomId, Pageable.ofSize(CHAT_MESSAGE_PAGE_SIZE));
 
     return message.map(ChatMessageDto::fromEntity);
+  }
+
+  @Override
+  public Page<ChatRoomResponse> findAllTagNameChatRoom(String performanceId, String tagName,
+      Pageable pageable) {
+    return chatRoomRepository.findAllTagNameChatRoom(performanceId,
+        tagName, pageable).map(ChatRoomResponse::fromEntity);
   }
 
   @Override

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -6,7 +6,6 @@ import static com.halfgallon.withcon.global.exception.ErrorCode.DUPLICATE_CHATRO
 import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.halfgallon.withcon.global.exception.ErrorCode.PARTICIPANT_NOT_FOUND;
 import static com.halfgallon.withcon.global.exception.ErrorCode.PERFORMANCE_NOT_FOUND;
-import static com.halfgallon.withcon.global.exception.ErrorCode.USER_JUST_ONE_CREATE_CHATROOM;
 
 import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
 import com.halfgallon.withcon.domain.chat.dto.ChatMessageDto;
@@ -59,7 +58,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     Member member = memberRepository.findById(customUserDetails.getId())
         .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
-    validationCreateChatroom(request, member.getUsername());
+    if (chatRoomRepository.existsByName(request.roomName())) {
+      throw new CustomException(DUPLICATE_CHATROOM);
+    }
 
     ChatRoom chatRoom = chatRoomRepository.save(request.toEntity(member.getUsername()));
 
@@ -231,20 +232,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     return ChatRoomResponse.fromEntity(chatParticipant.getChatRoom());
-  }
-
-  /**
-   * 채팅방 생성 유효성 검사
-   */
-  private void validationCreateChatroom(ChatRoomRequest request, String username) {
-    //채팅방 이름 검사
-    if (chatRoomRepository.existsByName(request.roomName())) {
-      throw new CustomException(DUPLICATE_CHATROOM);
-    }
-    //채팅방은 1인당 1개만 생성이 가능하다.
-    if (chatRoomRepository.existsByManagerName(username)) {
-      throw new CustomException(USER_JUST_ONE_CREATE_CHATROOM);
-    }
   }
 
 }

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -4,9 +4,9 @@ Content-Type: application/json
 Authorization: {{accessToken}}
 
 {
-  "roomName": "채팅방7",
-  "performanceId": 7,
-  "tags": ["#123", "#서울", "위드"]
+  "roomName": "채팅방3223345",
+  "performanceId": 1,
+  "tags": ["수지", "서서갈비", "콘서트"]
 }
 
 ### 채팅방 조회
@@ -48,3 +48,11 @@ Authorization: {{accessToken}}
 DELETE http://localhost:8080/chatRoom/{{chatRoomId}}/kick/{{memberId}}
 Content-Type: application/json
 Authorization: {{accessToken}}
+
+### 채팅방 태그로 검색
+< {%
+  request.variables.set("performanceId", "1")
+  request.variables.set("tag", "위드")
+%}
+GET http://localhost:8080/chatRoom/performance/{{performanceId}}/tag/{{tag}}
+Content-Type: application/json

--- a/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
@@ -165,7 +165,8 @@ class ChatRoomServiceImplTest {
   }
 
   @Test
-  @DisplayName("채팅방 생성 실패 - 1인당 1개만 생성 가능합니다.")
+  @Disabled
+  @DisplayName("채팅방 생성 실패 - 1인당 1개만 생성 가능합니다.(해당 조건 미사용)")
   void createChatRoom_FailByJustOne() {
     //given
     ChatRoomRequest request = new ChatRoomRequest("1번 채팅방", 1L,


### PR DESCRIPTION
## 📝작업 내용
태그 검색을 이용한 채팅방 목록 조회
 - 해당 `공연ID`와 `태그 이름`을 검색하여 해당 태그 정보를 가지고 있는 채팅방 조회
 - querydsl을 이용하여 left join 문 작성 및 페이지네이션 처리 진행

## 💬리뷰 참고사항
- [x] API 테스트 진행


## #️⃣연관된 이슈

close #114
