### PR TITLE
[refactor] 채팅 메시지 엔드포인트 변경 및 설정 추가

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageRequest.java
@@ -1,7 +1,16 @@
 package com.halfgallon.withcon.domain.chat.dto;
 
+import org.springframework.util.ObjectUtils;
+
 public record ChatMessageRequest(
-    Long lastMsgId
+    Long lastMsgId,
+    Integer limit
 ) {
+
+  public ChatMessageRequest {
+    if (ObjectUtils.isEmpty(limit) || limit == 0) {
+      limit = 0;
+    }
+  }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatMessageRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatMessageRepositoryImpl.java
@@ -31,7 +31,7 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
             chatMessage.room.id.eq(roomId)
         )
         .limit(pageable.getPageSize() + 1)  //마지막 페이지 확인을 위해서 +1 조회
-        .orderBy(chatMessage.id.desc())
+        .orderBy(chatMessage.sendAt.asc())
         .fetch();
 
     return new SliceImpl<>(messages, pageable, checkLastPage(messages, pageable));

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -197,7 +197,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
     Slice<ChatMessage> message = chatMessageRepository.findChatRoomMessage(
-        request.lastMsgId(), chatRoomId, Pageable.ofSize(CHAT_MESSAGE_PAGE_SIZE));
+        request.lastMsgId(), chatRoomId,
+        Pageable.ofSize(request.limit() != 0 ? request.limit() : CHAT_MESSAGE_PAGE_SIZE));
 
     return message.map(ChatMessageDto::fromEntity);
   }

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -18,7 +18,7 @@ Content-Type: application/json
 
 ### 채팅방 입장
 < {%
-  request.variables.set("chatRoomId", "5")
+  request.variables.set("chatRoomId", "1")
 %}
 GET http://localhost:8080/chatRoom/{{chatRoomId}}/enter
 Content-Type: application/json
@@ -36,8 +36,18 @@ Authorization: {{accessToken}}
 < {%
   request.variables.set("chatRoomId", "1")
 %}
-GET http://localhost:8080/chatRoom/{{chatRoomId}}/message?lastMsgId=12
-Content-Type: application/x-www-form-urlencoded
+GET http://localhost:8080/chatRoom/{{chatRoomId}}/message?lastMsgId=25
+Content-Type: application/json
+#Content-Type: application/x-www-form-urlencoded
+Authorization: {{accessToken}}
+
+### 채팅방 메시지 조회 + limit
+< {%
+  request.variables.set("chatRoomId", "1")
+%}
+GET http://localhost:8080/chatRoom/{{chatRoomId}}/message?lastMsgId=25&limit=5
+Content-Type: application/json
+#Content-Type: application/x-www-form-urlencoded
 Authorization: {{accessToken}}
 
 ### 채팅방 강퇴

--- a/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
@@ -300,7 +300,7 @@ class ChatRoomServiceImplTest {
   @DisplayName("채팅 메시지 조회")
   void findAllMessageChatRoom_firstPage() {
     //given
-    ChatMessageRequest request = new ChatMessageRequest(null);
+    ChatMessageRequest request = new ChatMessageRequest(null, null);
 
     ChatRoom chatRoom = ChatRoom.builder()
         .id(1L)


### PR DESCRIPTION
## 📝작업 내용

- 채팅 메시지 엔드포인트 변경 및 설정 추가 

   1. 채팅방 정보를 request 시에 lastMsgId와 limit 파라미터를 받아와서 클라이언트에서 마지막으로 읽은 메시지와 
   해당 메시지 limit를 설정하여 조회할 내용의 사이즈를 설정한다. 
   2. 클라이언트에서 limit가 `0`이거나 `null`인 경우에는 서버 측에서 설정해놓은 `page_size(10)`으로 고정해서 사용한다.

- 채팅 메시지 조회 정렬 변경
   1. 메시지 조회 시에 메시지를 보낸 날짜 순으로 정렬하여 조회한다.

## 💬리뷰 참고사항

- [x] API 테스트 진행
- [x] 테스트 코드 작성

## #️⃣연관된 이슈

close #116
