### PR TITLE
[refactor] 태그 검색 시 공연 정보 조회 리팩토링

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/controller/TagController.java
@@ -26,12 +26,14 @@ public class TagController {
   }
 
   /**
-   * 태그 이름 검색 시에 태그 갯수가 많은 순으로 정렬
-   * @return : tagName(태그 이름), count(태그 생성 갯수)
+   * 공연에 따른 태그 이름 검색
+   * @return : tagName(태그 이름), count(태그 생성 갯수), performanceId(공연 ID)
    */
-  @GetMapping("/{tagName}/search")
-  public ResponseEntity<?> findTagNameOrderByCount(@PathVariable("tagName") String tagName) {
-    return ResponseEntity.ok(tagService.findTagNameOrderByCount(tagName));
+  @GetMapping("/{tagName}/search/performance/{performanceId}")
+  public ResponseEntity<?> findTagNameOrderByCount(
+      @PathVariable("tagName") String tagName,
+      @PathVariable("performanceId") String performanceId) {
+    return ResponseEntity.ok(tagService.findTagNameOrderByCount(tagName, performanceId));
   }
 
   /**

--- a/src/main/java/com/halfgallon/withcon/domain/tag/dto/TagCountDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/dto/TagCountDto.java
@@ -6,4 +6,5 @@ import lombok.Getter;
 public class TagCountDto {
   private String name;
   private Long count;
+  private String performance;
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/CustomTagRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/CustomTagRepository.java
@@ -7,5 +7,5 @@ public interface CustomTagRepository {
 
   List<TagCountDto> findTagOrderByCount();
 
-  List<TagCountDto> findTagNameOrderByCount(String name);
+  List<TagCountDto> findTagNameOrderByCount(String name, String performanceId);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/repository/impl/CustomTagRepositoryImpl.java
@@ -17,10 +17,10 @@ public class CustomTagRepositoryImpl implements CustomTagRepository {
   @Override
   public List<TagCountDto> findTagOrderByCount() {
     return jpaQueryFactory.select(
-        Projections.fields(TagCountDto.class,
-            tag.name,
-            tag.count().as("count")
-        ))
+            Projections.fields(TagCountDto.class,
+                tag.name,
+                tag.count().as("count"),
+                tag.performance.name.as("performance")))
         .from(tag)
         .orderBy(tag.count().desc())
         .groupBy(tag.name)
@@ -29,13 +29,14 @@ public class CustomTagRepositoryImpl implements CustomTagRepository {
   }
 
   @Override
-  public List<TagCountDto> findTagNameOrderByCount(String name) {
+  public List<TagCountDto> findTagNameOrderByCount(String name, String performanceId) {
     return jpaQueryFactory.select(
             Projections.fields(TagCountDto.class,
                 tag.name,
-                tag.count().as("count")))
+                tag.count().as("count"),
+                tag.performance.name.as("performance")))
         .from(tag)
-        .where(tag.name.contains(name))
+        .where(tag.name.startsWithIgnoreCase(name), tag.performance.id.eq(performanceId))
         .groupBy(tag.name)
         .orderBy(tag.count().desc())
         .limit(10)

--- a/src/main/java/com/halfgallon/withcon/domain/tag/service/TagService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/service/TagService.java
@@ -8,7 +8,7 @@ public interface TagService {
 
   List<TagCountDto> findTagOrderByCount();
 
-  List<TagCountDto> findTagNameOrderByCount(String tagName);
+  List<TagCountDto> findTagNameOrderByCount(String tagName, String performanceId);
 
   List<TagSearchDto> findTagKeyword(String performanceId, String keyword);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/tag/service/TagServiceImpl.java
@@ -25,8 +25,8 @@ public class TagServiceImpl implements TagService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<TagCountDto> findTagNameOrderByCount(String tagName) {
-    return tagRepository.findTagNameOrderByCount(tagName);
+  public List<TagCountDto> findTagNameOrderByCount(String tagName, String performanceId) {
+    return tagRepository.findTagNameOrderByCount(tagName, performanceId);
   }
 
   @Override

--- a/src/test/http/tag.http
+++ b/src/test/http/tag.http
@@ -1,18 +1,18 @@
-### 태그 정보 조회(태그 갯수가 많은 순으로 정렬)
+### 태그 정보 조회(default)
 GET http://localhost:8080/tag/search
 Content-Type: application/json
 
-
-### 태그 이름 검색(태그 갯수가 많은 순으로 정렬)
+### 태그 이름 검색(+ 공연 ID)
 < {%
-  request.variables.set("tags", "위드")
+  request.variables.set("tagName", "위")
+  request.variables.set("performanceId", "1")
 %}
-GET http://localhost:8080/tag/{{tags}}/search
+GET http://localhost:8080/tag/{{tagName}}/search/performance/{{performanceId}}
 Content-Type: application/json
 
-### 태그 자동완성
+### 태그 자동완성(ElasticSearch)
 < {%
   request.variables.set("keyword", "수")
 %}
-GET http://localhost:8080/tag/search?performance=1&keyword={{keyword}}
+GET http://localhost:8080/tag/search/autocomplete?performance=1&keyword={{keyword}}
 Content-Type: application/json

--- a/src/test/java/com/halfgallon/withcon/domain/tag/repository/TagRepositoryTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/tag/repository/TagRepositoryTest.java
@@ -3,6 +3,7 @@ package com.halfgallon.withcon.domain.tag.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.halfgallon.withcon.domain.performance.entitiy.Performance;
 import com.halfgallon.withcon.domain.tag.dto.TagCountDto;
 import com.halfgallon.withcon.domain.tag.entity.Tag;
 import com.halfgallon.withcon.global.config.ElasticSearchConfig;
@@ -62,30 +63,38 @@ class TagRepositoryTest {
   @Test
   @DisplayName("태그 이름 검색 - 태그 갯수가 많은 순으로 정렬")
   void findTagNameOrderByCount() {
+
+    Performance performance = Performance.builder()
+        .id("1").name("공연1").build();
+
     //given
     for (int i = 0; i < 2; i++) {
       tagRepository.save(Tag.builder()
           .name("위드콘")
+          .performance(performance)
           .build());
     }
 
     tagRepository.save(Tag.builder()
         .name("위드")
+        .performance(performance)
         .build());
 
     tagRepository.save(Tag.builder()
         .name("콘서트")
+        .performance(performance)
         .build());
 
     tagRepository.save(Tag.builder()
         .name("월드콘")
+        .performance(performance)
         .build());
 
     //when
-    List<TagCountDto> response = tagRepository.findTagNameOrderByCount("콘");
+    List<TagCountDto> response = tagRepository.findTagNameOrderByCount("콘", "1");
 
     //then
     assertThat(response.size()).isNotZero();
-    assertThat(response.get(0).getName()).isEqualTo("위드콘");
+    assertThat(response.get(0).getName()).isEqualTo("콘서트");
   }
 }


### PR DESCRIPTION
## 📝작업 내용

- 태그 검색 시 공연 정보 조회 리팩토링

   1. 태그 이름 조회 시에 `name` + `performanceId`를 매개변수로 이용하여 해당 공연에 설정되어 있는 태그를 조회한다.
   2. QueryDsl을 이용해서 DTO 반환 시에 `performance` 추가하여 반환해준다.
   3. 공연에 따른 태그 이름 검색 엔드포인트 수정(`performanceId` 추가)

## 💬리뷰 참고사항

- [x] API 테스트 진행

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/df1a0182-aeb5-446e-a59e-3ae610cc7943)
![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/a09922a4-eb6d-4fd8-a037-20f2bdf3facc)


## #️⃣연관된 이슈

close #118
