### PR TITLE
[Refactor] 채팅방 입장/퇴장/강퇴 알림에 대한 VIsible 조건 추가 

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/handler/NotificationScheduleHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/handler/NotificationScheduleHandler.java
@@ -38,10 +38,10 @@ public class NotificationScheduleHandler {
   }
 
   @Transactional
-  @Scheduled(cron = "0 */3 20-22 * * *") // 매일 자정에 오픈 공연 조회 후 알림 생성
+  @Scheduled(cron = "0 */3 17-18 * * *") // 매일 자정에 오픈 공연 조회 후 알림 생성
   public void createPerformanceOpenNotification() {
     LocalDate today = LocalDate.now();
-    LocalDate day = today.minusDays(20);
+    LocalDate day = today.minusDays(21);
     List<Performance> todayPerformances = performanceRepository.findAllByStartDate(day);
     log.info("Scheduler : 오픈 당일 공연 조회 성공");
 

--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/NotificationServiceImpl.java
@@ -8,18 +8,22 @@ import com.halfgallon.withcon.domain.member.repository.MemberRepository;
 import com.halfgallon.withcon.domain.notification.constant.Channel;
 import com.halfgallon.withcon.domain.notification.constant.NotificationMessage;
 import com.halfgallon.withcon.domain.notification.constant.NotificationType;
+import com.halfgallon.withcon.domain.notification.constant.RedisCacheType;
+import com.halfgallon.withcon.domain.notification.constant.VisibleType;
 import com.halfgallon.withcon.domain.notification.dto.ChatRoomNotificationRequest;
 import com.halfgallon.withcon.domain.notification.dto.NotificationResponse;
 import com.halfgallon.withcon.domain.notification.entity.Notification;
 import com.halfgallon.withcon.domain.notification.repository.NotificationRepository;
 import com.halfgallon.withcon.domain.notification.repository.SseEmitterRepository;
 import com.halfgallon.withcon.domain.notification.service.NotificationService;
+import com.halfgallon.withcon.domain.notification.service.RedisCacheService;
 import com.halfgallon.withcon.domain.notification.service.RedisNotificationService;
 import com.halfgallon.withcon.domain.notification.service.SseEmitterService;
 import com.halfgallon.withcon.global.exception.CustomException;
 import com.halfgallon.withcon.global.exception.ErrorCode;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +46,7 @@ public class NotificationServiceImpl implements NotificationService {
 
   private final SseEmitterService sseEmitterService;
   private final RedisNotificationService redisNotificationService;
+  private final RedisCacheService redisCacheService;
 
   @Override
   public SseEmitter subscribe(Long memberId) {
@@ -95,23 +100,44 @@ public class NotificationServiceImpl implements NotificationService {
         findAllByChatRoom_Id(request.getChatRoomId());
     log.info("Service : 참여 멤버 조회 성공");
 
+    String message = createMessageOfTarget(request);
+    String url = createChatRoomUrl(request.getChatRoomId());
+    log.info("Service : url 생성");
+
+    String visibleKey = RedisCacheType.VISIBLE_CACHE.getDescription()
+        + request.getChatRoomId();
+    log.info("Service : 채널 KEY: " + visibleKey);
+
+    Map<Object, Object> cache = redisCacheService.getHashByKey(visibleKey);
+    log.info("Service : Visible 캐시 데이터 조회" + cache);
+
+    for (ChatParticipant chatParticipant : chatParticipants) {
+      Member participantMember = chatParticipant.getMember();
+
+      if (Objects.equals(participantMember.getId(), request.getTargetId())) {
+        log.info("Service : Target은 제외");
+        continue;
+      }
+
+      if(!cache.containsKey(String.valueOf(chatParticipant.getId()))) {
+        continue;
+      }
+
+      VisibleType visibleType = (VisibleType)cache.get(String.valueOf(chatParticipant.getId()));
+      if(visibleType == VisibleType.HIDDEN || visibleType == VisibleType.NONE) {
+        notificationSaveAndPublish(request, message, url, participantMember);
+      }
+    }
+  }
+
+  private String createMessageOfTarget(ChatRoomNotificationRequest request) {
     Member member = memberRepository.findById(request.getTargetId())
         .orElse(withdrawMember());
     log.info("Service : Target 맴버 조회 성공");
     String message = createChatRoomMessage(member.getUsername(),
         request.getMessageType()); // 메세지 생성
     log.info("Service : 알림 메세지 생성");
-    String url = createChatRoomUrl(request.getChatRoomId());
-    log.info("Service : url 생성");
-
-    for (ChatParticipant chatParticipant : chatParticipants) {
-      Member participantMember = chatParticipant.getMember();
-      if (Objects.equals(participantMember.getId(), request.getTargetId())) {
-        log.info("Service : Target은 제외");
-        continue;
-      }
-      notificationSaveAndPublish(request, message, url, participantMember);
-    }
+    return message;
   }
 
   private void notificationSaveAndPublish(ChatRoomNotificationRequest request, String message, String url,

--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/NotificationServiceImpl.java
@@ -119,11 +119,14 @@ public class NotificationServiceImpl implements NotificationService {
         continue;
       }
 
-      if(!cache.containsKey(String.valueOf(chatParticipant.getId()))) {
+      if(!cache.containsKey(String.valueOf(participantMember.getId()))) {
+        log.info("패스");
         continue;
       }
 
-      VisibleType visibleType = (VisibleType)cache.get(String.valueOf(chatParticipant.getId()));
+      VisibleType visibleType = VisibleType.valueOf(
+          (String)cache.get(String.valueOf(participantMember.getId())));
+
       if(visibleType == VisibleType.HIDDEN || visibleType == VisibleType.NONE) {
         notificationSaveAndPublish(request, message, url, participantMember);
       }


### PR DESCRIPTION
## 📝작업 내용

- 채팅방 입장/퇴장/강퇴 알림에 대한 Visible 조건 추가 

작업내용

## 💬리뷰 참고사항

- 기존에 채팅방에 누군가 입장/퇴장/강퇴 상황이 날 때 채팅방 참여 멤버들에게 알림이 갔습니다. 
- 수정 : 채팅방 참여 멤버 중 Redis VisibleType 정보가 NONE이거나 HIDDEN일 때만 알림을 보냅니다. 

- HIDDEN은 채팅방을 안보고 있을 때 상태고, NONE은 채팅방을 안보고 있는 회원이 "새 메세지 알림"을 받은 상태입니다.  NONE으로 변경하는 이유는 채팅방 새 메세지에 대해 한 번만 알림을 보내기 위함입니다. 

- 하지만 채팅방 입장/퇴장/강퇴 알림은 다수의 상황에 대해 1회성이 아니기 때문에 NONE상태에서도 보냅니다. 이후 VISIBLE 상태가 온다면 알림이 가지 않습니다. 


참고사항

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

(close) #108 
