### PR TITLE
[refactor] 채팅 response 변경

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantDto.java
@@ -17,7 +17,6 @@ public record ChatParticipantDto(
   public static ChatParticipantDto fromEntity(ChatParticipant chatParticipant) {
     return ChatParticipantDto.builder()
         .memberId(chatParticipant.getMember().getId())
-//        .username(chatParticipant.getMember().getUsername())
         .password(chatParticipant.getMember().getPassword())
         .userProfile(chatParticipant.getMember().getProfileImage())
         .loginType(chatParticipant.getMember().getLoginType())

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantDto.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record ChatParticipantDto(
-    String username,
+    Long memberId,
     String password,
     String userProfile,
     LoginType loginType,
@@ -16,7 +16,8 @@ public record ChatParticipantDto(
 
   public static ChatParticipantDto fromEntity(ChatParticipant chatParticipant) {
     return ChatParticipantDto.builder()
-        .username(chatParticipant.getMember().getUsername())
+        .memberId(chatParticipant.getMember().getId())
+//        .username(chatParticipant.getMember().getUsername())
         .password(chatParticipant.getMember().getPassword())
         .userProfile(chatParticipant.getMember().getProfileImage())
         .loginType(chatParticipant.getMember().getLoginType())

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomEnterResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomEnterResponse.java
@@ -5,10 +5,10 @@ import lombok.Builder;
 
 @Builder
 public record ChatRoomEnterResponse(
+    Long managerId,
     Long chatRoomId,
     String performanceName,
     String roomName,
-    String managerName,
     Integer userCount,
     List<ChatParticipantDto> chatParticipants
 ) {

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomRequest.java
@@ -8,10 +8,10 @@ public record ChatRoomRequest(
     String performanceId,
     List<String> tags
 ) {
-  public ChatRoom toEntity(String username) {
+  public ChatRoom toEntity(Long userId) {
     return ChatRoom.builder()
         .name(this.roomName)
-        .managerName(username)
+        .managerId(userId)
         .build();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomResponse.java
@@ -9,9 +9,9 @@ import lombok.Builder;
 
 @Builder
 public record ChatRoomResponse(
+    Long managerId,
     Long chatRoomId,
     String roomName,
-    String managerName,
     String performanceId,
     Integer userCount,
     List<String> tags,
@@ -23,7 +23,7 @@ public record ChatRoomResponse(
     return ChatRoomResponse.builder()
         .chatRoomId(chatRoom.getId())
         .roomName(chatRoom.getName())
-        .managerName(chatRoom.getManagerName())
+        .managerId(chatRoom.getManagerId())
         .performanceId(chatRoom.getPerformance().getId())
         .userCount(chatRoom.getUserCount())
         .tags(chatRoom.getTags().stream().map(Tag::getName).toList())

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatRoom.java
@@ -50,7 +50,7 @@ public class ChatRoom extends BaseTimeEntity {
   private Performance performance;
 
   @Column(nullable = false)
-  private String managerName;
+  private Long managerId;
 
   public void updateUserCount() {
     this.userCount = this.chatParticipants.size();
@@ -68,10 +68,6 @@ public class ChatRoom extends BaseTimeEntity {
 
   public void addTag(Tag tag) {
     this.tags.add(tag);
-  }
-
-  public void updatePerformance(Performance performance) {
-    this.performance = performance;
   }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatRoomRepository.java
@@ -8,9 +8,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, CustomChatRoomRepository {
-  boolean existsByName(String name);
+  boolean existsByNameAndPerformance_Id(String name, String performanceId);
 
   Page<ChatRoom> findAllByPerformance_Id(String performanceId, Pageable pageable);
-
-  boolean existsByManagerName(String managerName);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatParticipantRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/CustomChatParticipantRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface CustomChatParticipantRepository {
 
-  boolean checkRoomManagerName(String managerName);
+  boolean checkRoomManagerId(Long managerId);
 
   Page<ChatParticipant> findAllMyChattingRoom(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatParticipantRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatParticipantRepositoryImpl.java
@@ -19,14 +19,14 @@ public class CustomChatParticipantRepositoryImpl implements CustomChatParticipan
   private final JPAQueryFactory jpaQueryFactory;
 
   @Override
-  public boolean checkRoomManagerName(String managerName) {
-    Integer i = jpaQueryFactory.selectOne()
+  public boolean checkRoomManagerId(Long managerId) {
+    Integer integer = jpaQueryFactory.selectOne()
         .from(chatParticipant)
         .leftJoin(chatParticipant.chatRoom, chatRoom)
-        .where(chatRoom.managerName.eq(managerName))
+        .where(chatRoom.managerId.eq(managerId))
         .fetchFirst();
 
-    return i != null;
+    return integer != null;
   }
 
   @Override

--- a/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
+++ b/src/main/java/com/halfgallon/withcon/global/exception/ErrorCode.java
@@ -49,7 +49,7 @@ public enum ErrorCode {
   /**
    * 409 conflict
    */
-  DUPLICATE_CHATROOM(CONFLICT.value(), "이미 존재하는 채팅방입니다."),
+  DUPLICATE_CHATROOM_NAME(CONFLICT.value(), "이미 사용하는 채팅방 이름입니다."),
   DUPLICATE_USERNAME(CONFLICT.value(), "이미 사용하고 있는 ID 입니다."),
   DUPLICATE_PHONE_NUMBER(CONFLICT.value(), "이미 사용하고 있는 핸드폰 번호입니다."),
   ALREADY_LIKE_EXIST(CONFLICT.value(), "이미 찜한 공연입니다."),

--- a/src/test/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/controller/ChatRoomControllerTest.java
@@ -63,7 +63,7 @@ class ChatRoomControllerTest {
     //when
     //then
     ChatRoomRequest request = new ChatRoomRequest("1번 채팅방",
-        1L, List.of("#1번방", "#2번방"));
+        "1", List.of("#1번방", "#2번방"));
 
     mockMvc.perform(post("/chatRoom")
         .contentType(MediaType.APPLICATION_JSON)
@@ -82,7 +82,7 @@ class ChatRoomControllerTest {
 
     //when
     //then
-    ChatRoomRequest request = new ChatRoomRequest("1번 채팅방", 1L, null);
+    ChatRoomRequest request = new ChatRoomRequest("1번 채팅방", "1", null);
 
     mockMvc.perform(post("/chatRoom")
             .contentType(MediaType.APPLICATION_JSON)
@@ -93,7 +93,7 @@ class ChatRoomControllerTest {
 
   private static ChatRoomResponse getChatRoomResponse() {
     return ChatRoomResponse.builder()
-        .performanceId(12345L)
+        .performanceId("1234")
         .chatRoomId(1L)
         .roomName("1번 채팅방")
         .build();

--- a/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.halfgallon.withcon.domain.chat.service.impl;
 
-import static com.halfgallon.withcon.global.exception.ErrorCode.DUPLICATE_CHATROOM;
+import static com.halfgallon.withcon.global.exception.ErrorCode.DUPLICATE_CHATROOM_NAME;
 import static com.halfgallon.withcon.global.exception.ErrorCode.USER_JUST_ONE_CREATE_CHATROOM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -93,7 +93,7 @@ class ChatRoomServiceImplTest {
   @DisplayName("채팅방 생성 성공")
   void createChatRoom_Success() {
     //given
-    ChatRoomRequest request = new ChatRoomRequest("1번채팅방", 1L,
+    ChatRoomRequest request = new ChatRoomRequest("1번채팅방", "1",
         List.of("#1번방", "#2번방"));
 
     ChatRoom chatRoom = ChatRoom.builder()
@@ -104,10 +104,10 @@ class ChatRoomServiceImplTest {
     given(memberRepository.findById(anyLong()))
         .willReturn(Optional.of(member));
 
-    given(chatRoomRepository.existsByName(anyString()))
+    given(chatRoomRepository.existsByNameAndPerformance_Id(anyString(), anyString()))
         .willReturn(false);
 
-    given(chatParticipantRepository.checkRoomManagerName(anyString()))
+    given(chatParticipantRepository.checkRoomManagerId(anyLong()))
         .willReturn(false);
 
     Performance performance = Performance.builder()
@@ -150,10 +150,16 @@ class ChatRoomServiceImplTest {
     given(memberRepository.findById(anyLong()))
         .willReturn(Optional.of(member));
 
-    given(chatRoomRepository.existsByName(anyString()))
+    given(performanceRepository.findById(anyString()))
+        .willReturn(Optional.of(Performance.builder()
+            .id("123456")
+            .name("1번 공연")
+            .build()));
+
+    given(chatRoomRepository.existsByNameAndPerformance_Id(anyString(), anyString()))
         .willReturn(true);
 
-    ChatRoomRequest request = new ChatRoomRequest("1번 채팅방", 1L,
+    ChatRoomRequest request = new ChatRoomRequest("1번 채팅방", "1",
         List.of("#1번방", "#2번방"));
 
     //when
@@ -161,7 +167,7 @@ class ChatRoomServiceImplTest {
         () -> chatRoomService.createChatRoom(customUserDetails, request));
 
     //then
-    assertThat(DUPLICATE_CHATROOM.getStatus()).isEqualTo(customException.getErrorCode().getStatus());
+    assertThat(DUPLICATE_CHATROOM_NAME.getStatus()).isEqualTo(customException.getErrorCode().getStatus());
   }
 
   @Test
@@ -169,13 +175,13 @@ class ChatRoomServiceImplTest {
   @DisplayName("채팅방 생성 실패 - 1인당 1개만 생성 가능합니다.(해당 조건 미사용)")
   void createChatRoom_FailByJustOne() {
     //given
-    ChatRoomRequest request = new ChatRoomRequest("1번 채팅방", 1L,
+    ChatRoomRequest request = new ChatRoomRequest("1번 채팅방", "1",
         List.of("#1번방", "#2번방"));
 
     given(memberRepository.findById(anyLong()))
         .willReturn(Optional.of(member));
 
-    given(chatRoomRepository.existsByManagerName(anyString()))
+    given(chatRoomRepository.existsByNameAndPerformance_Id(anyString(),anyString()))
         .willReturn(true);
 
     //when
@@ -276,7 +282,7 @@ class ChatRoomServiceImplTest {
     ChatRoom chatRoom = ChatRoom.builder()
         .id(1L)
         .name("1번채팅방")
-        .managerName(member.getUsername())
+        .managerId(member.getId())
         .performance(performance)
         .build();
 
@@ -369,7 +375,7 @@ class ChatRoomServiceImplTest {
             .member(user)
             .build()));
 
-    given(chatParticipantRepository.checkRoomManagerName(anyString()))
+    given(chatParticipantRepository.checkRoomManagerId(anyLong()))
         .willReturn(true);
 
     //when


### PR DESCRIPTION
## 📝작업 내용
1. 채팅 response 변경
    1. ChatParticipantDto.username -> ChatParticipantDto.memberId
    2. ChatRoomEnterResponse.managerName -> ChatRoomEnterResponse.managerId

2. 채팅 repository 메서드 변경
    1. existsByName -> existsByNameAndPerformance_Id 변경
        - 공연에 속해있는 채팅방의 이름이 동일한 경우 exception 진행
    2. ManagerName -> ManagerId
        - ManagerId를 이용하여 방장 여부 체크

3. ErrorCode 네이밍 변경

## 💬리뷰 참고사항
- [x] API 테스트(managerName -> managerId)

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/205c492f-3b55-4995-afe7-0ca7581e8657)

- [x] 테스트 코드 작성

## #️⃣연관된 이슈

close #123 