### PR TITLE
[feat] 채팅 접속 및 마지막 메시지 ID 저장

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/config/Handler/StompPreHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/config/Handler/StompPreHandler.java
@@ -1,0 +1,157 @@
+package com.halfgallon.withcon.domain.chat.config.Handler;
+
+import static com.halfgallon.withcon.domain.auth.constant.AuthConstant.ACCESS_TOKEN_PREFIX;
+import static com.halfgallon.withcon.domain.chat.constant.ChattingConstant.CHATROOM_SESSION;
+import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.halfgallon.withcon.domain.auth.entity.AccessToken;
+import com.halfgallon.withcon.domain.auth.repository.AccessTokenRepository;
+import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
+import com.halfgallon.withcon.domain.chat.dto.ChatRoomSessionDto;
+import com.halfgallon.withcon.domain.chat.entity.ChatRoom;
+import com.halfgallon.withcon.domain.chat.repository.ChatMessageRepository;
+import com.halfgallon.withcon.domain.chat.repository.ChatParticipantRepository;
+import com.halfgallon.withcon.domain.chat.repository.ChatRoomRepository;
+import com.halfgallon.withcon.domain.member.entity.Member;
+import com.halfgallon.withcon.domain.member.repository.MemberRepository;
+import com.halfgallon.withcon.domain.notification.service.RedisService;
+import com.halfgallon.withcon.global.exception.CustomException;
+import com.halfgallon.withcon.global.exception.ErrorCode;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompPreHandler implements ChannelInterceptor {
+
+  private final MemberRepository memberRepository;
+  private final ChatRoomRepository chatRoomRepository;
+  private final AccessTokenRepository accessTokenRepository;
+  private final ChatParticipantRepository participantRepository;
+  private final ChatMessageRepository chatMessageRepository;
+
+  private final RedisService redisService;
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor =
+        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+    assert accessor != null;
+    if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+      String token = resolveToken(accessor.getFirstNativeHeader("Authorization"));
+
+      AccessToken findAccessToken = findAccessTokenOrThrow(token);
+
+      Member member = findMemberOrThrow(findAccessToken.getMemberId());
+
+      // WS Header save to userData
+      accessor.setUser(authenticate(member));
+
+      log.info("[preSend] stomp connection => user : {}, sessionId : {}",
+          Objects.requireNonNull(accessor.getUser()).getName(),
+          accessor.getSessionId());
+
+    } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+      log.info("[preSend] stomp subscribe. destination: {}, user: {}, sessionId : {}",
+          accessor.getDestination(),
+          Objects.requireNonNull(accessor.getUser()).getName(),
+          accessor.getSessionId());
+
+      String sessionId = accessor.getSessionId();
+
+      Member member = memberRepository.findByUsername(accessor.getUser().getName())
+          .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+      Long roomId = getRoomIdFromDestination(Objects.requireNonNull(accessor.getDestination()));
+      ChatRoom chatRoom = findChatRoomOrThrow(roomId);
+
+      saveSession(chatRoom.getId(), member.getId(), sessionId);
+
+    } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+      String sessionId = accessor.getSessionId();
+      ChatRoomSessionDto sessionDto = redisService.getChatRoomHashKey(CHATROOM_SESSION, sessionId);
+
+      try {
+        assert sessionDto != null;
+        ChatRoom chatRoom = findChatRoomOrThrow(sessionDto.chatRoomId());
+        Member member = findMemberOrThrow(sessionDto.memberId());
+
+        //채팅방 뒤로 가기 진행 시에 마지막 메시지 ID 업데이트 진행
+        participantRepository.findByMemberIdAndChatRoomId(member.getId(), chatRoom.getId())
+                .ifPresent(p ->
+                    chatMessageRepository.findTopByChatRoomIdOrderBySendAtDesc(chatRoom.getId())
+                    .ifPresent(chatMessage -> {
+                      p.updateLastReadId(chatMessage.getId());
+                      participantRepository.save(p);
+                    })
+                );
+
+      } catch (Exception e) {
+        log.error("[preSend] stomp disconnect is occurred : {}", e.getMessage());
+      } finally {
+        redisService.deleteHashKey(CHATROOM_SESSION, sessionId);
+      }
+    }
+
+    return message;
+  }
+
+  private String resolveToken(String token) {
+    if (StringUtils.hasText(token) && token.startsWith(ACCESS_TOKEN_PREFIX)) {
+      return token.substring(ACCESS_TOKEN_PREFIX.length());
+    }
+    throw new CustomException(ErrorCode.ACCESS_TOKEN_NOT_SUPPORTED);
+  }
+
+  private Member findMemberOrThrow(Long memberId) {
+    return memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+  }
+
+  private ChatRoom findChatRoomOrThrow(Long chatRoomId) {
+    return chatRoomRepository.findById(chatRoomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.CHATROOM_NOT_FOUND));
+  }
+
+  private AccessToken findAccessTokenOrThrow(String token) {
+    return accessTokenRepository.findByAccessToken(token)
+        .orElseThrow(() -> new CustomException(ErrorCode.ACCESS_TOKEN_EXPIRED));
+  }
+
+  private Authentication authenticate(Member member) {
+    CustomUserDetails principal = CustomUserDetails.fromEntity(member);
+    Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "",
+        principal.getAuthorities());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    return authentication;
+  }
+
+  private Long getRoomIdFromDestination(String destination) {
+    return Long.parseLong(destination.substring(destination.lastIndexOf(".") + 1));
+  }
+
+  private void saveSession(Long chatRoomId, Long memberId, String sessionId) {
+    ChatRoomSessionDto sessionDto = ChatRoomSessionDto.builder()
+        .chatRoomId(chatRoomId)
+        .memberId(memberId)
+        .build();
+
+    redisService.updateToHash(CHATROOM_SESSION, sessionId, sessionDto);
+  }
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/config/WebSocketConfig.java
@@ -1,15 +1,21 @@
 package com.halfgallon.withcon.domain.chat.config;
 
+import com.halfgallon.withcon.domain.chat.config.Handler.StompPreHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  private final StompPreHandler stompPreHandler;
 
   @Value("${relay.host}")
   private String relayHost;
@@ -48,4 +54,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
   }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(stompPreHandler);
+  }
+
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/constant/ChattingConstant.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/constant/ChattingConstant.java
@@ -5,4 +5,5 @@ public class ChattingConstant {
   public static final String CHAT_EXCHANGE_NAME = "chat.exchange";
   public static final String ROUTING_KEY = "room.*";
   public static final Integer CHAT_MESSAGE_PAGE_SIZE = 10;
+  public static final String CHATROOM_SESSION = "CHATROOM_SESSION";
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/constant/EnterStatus.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/constant/EnterStatus.java
@@ -1,0 +1,8 @@
+package com.halfgallon.withcon.domain.chat.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum EnterStatus {
+  NEW, ALREADY
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatParticipantController.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/controller/ChatParticipantController.java
@@ -1,6 +1,7 @@
 package com.halfgallon.withcon.domain.chat.controller;
 
 import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
+import com.halfgallon.withcon.domain.chat.dto.ChatLastReadMessage;
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantResponse;
 import com.halfgallon.withcon.domain.chat.service.ChatParticipantService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,6 +26,11 @@ public class ChatParticipantController {
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @PageableDefault(size = 5) Pageable pageable) {
     return ResponseEntity.ok(chatParticipantService.findMyChatRoom(customUserDetails, pageable));
+  }
+
+  @PostMapping("/chatRoom/lastChat")
+  public ResponseEntity<?> readToLastChat(@RequestBody ChatLastReadMessage.Request request) {
+    return ResponseEntity.ok(chatParticipantService.readToLastChat(request));
   }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatLastReadMessage.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatLastReadMessage.java
@@ -1,0 +1,37 @@
+package com.halfgallon.withcon.domain.chat.dto;
+
+import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChatLastReadMessage {
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class Request {
+    private Long memberId;
+    private Long chatRoomId;
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class Response {
+    private Long memberId;
+    private Long chatRoomId;
+    private Long lastMsgId;
+
+    public static ChatLastReadMessage.Response fromEntity(ChatParticipant chatParticipant) {
+      return ChatLastReadMessage.Response.builder()
+          .memberId(chatParticipant.getMember().getId())
+          .chatRoomId(chatParticipant.getChatRoom().getId())
+          .lastMsgId(chatParticipant.getLastReadId())
+          .build();
+    }
+  }
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageDto.java
@@ -2,6 +2,7 @@ package com.halfgallon.withcon.domain.chat.dto;
 
 import com.halfgallon.withcon.domain.chat.constant.MessageType;
 import com.halfgallon.withcon.domain.chat.entity.ChatMessage;
+import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,13 +33,15 @@ public class ChatMessageDto {
         .build();
   }
 
-  public static ChatMessageDto fromEntity(ChatMessage chatMessage) {
+  public static ChatMessageDto fromEntity(ChatMessage chatMessage, ChatParticipant chatParticipant) {
     return ChatMessageDto.builder()
-        .roomId(chatMessage.getRoom().getId())
+        .roomId(chatMessage.getChatRoom().getId())
         .memberId(chatMessage.getChatParticipant().getId())
         .message(chatMessage.getMessage())
         .messageType(chatMessage.getMessageType())
         .sendAt(chatMessage.getSendAt())
+        .nickName(chatParticipant.getMember().getNickname())
+        .userProfile(chatParticipant.getMember().getProfileImage())
         .build();
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatParticipantResponse.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 public record ChatParticipantResponse(
     Long memberId,
     Long chatRoomId,
-    String chatRoomName,
+    String roomName,
     List<String> tags
 ) {
 
@@ -17,7 +17,7 @@ public record ChatParticipantResponse(
     return ChatParticipantResponse.builder()
         .memberId(participant.getMember().getId())
         .chatRoomId(participant.getChatRoom().getId())
-        .chatRoomName(participant.getChatRoom().getName())
+        .roomName(participant.getChatRoom().getName())
         .tags(participant.getChatRoom().getTags().stream().map(Tag::getName).toList())
         .build();
   }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomEnterResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomEnterResponse.java
@@ -1,5 +1,6 @@
 package com.halfgallon.withcon.domain.chat.dto;
 
+import com.halfgallon.withcon.domain.chat.constant.EnterStatus;
 import java.util.List;
 import lombok.Builder;
 
@@ -7,9 +8,10 @@ import lombok.Builder;
 public record ChatRoomEnterResponse(
     Long managerId,
     Long chatRoomId,
-    String performanceName,
     String roomName,
     Integer userCount,
+    EnterStatus enterStatus,
+    String performanceName,
     List<ChatParticipantDto> chatParticipants
 ) {
 

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomSessionDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatRoomSessionDto.java
@@ -1,0 +1,11 @@
+package com.halfgallon.withcon.domain.chat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChatRoomSessionDto(
+    Long memberId,
+    Long chatRoomId
+) {
+
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatMessage.java
@@ -28,8 +28,8 @@ public class ChatMessage {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "room_id")
-  private ChatRoom room;
+  @JoinColumn(name = "chatRoom_id")
+  private ChatRoom chatRoom;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chatParticipant_id")
@@ -45,7 +45,7 @@ public class ChatMessage {
   private Long sendAt;
 
   public void updateChatRoom(ChatRoom chatRoom) {
-    this.room = chatRoom;
+    this.chatRoom = chatRoom;
   }
 
   public void updateChatParticipant(ChatParticipant chatParticipant) {

--- a/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/entity/ChatParticipant.java
@@ -1,6 +1,7 @@
 package com.halfgallon.withcon.domain.chat.entity;
 
 import com.halfgallon.withcon.domain.member.entity.Member;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -31,4 +32,11 @@ public class ChatParticipant {
   @ManyToOne
   @JoinColumn(name = "chatRoom_id")
   private ChatRoom chatRoom;
+
+  @Column(nullable = false)
+  private Long lastReadId;
+
+  public void updateLastReadId(Long lastReadId) {
+    this.lastReadId = lastReadId;
+  }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatMessageRepository.java
@@ -1,11 +1,13 @@
 package com.halfgallon.withcon.domain.chat.repository;
 
 import com.halfgallon.withcon.domain.chat.entity.ChatMessage;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     CustomChatMessageRepository{
+  Optional<ChatMessage> findTopByChatRoomIdOrderBySendAtDesc(Long chatRoomId);
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatParticipantRepository.java
@@ -11,6 +11,8 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     CustomChatParticipantRepository {
   Optional<ChatParticipant> findByMemberIdAndChatRoomId(Long memberId, Long roomId);
 
+  boolean existsByMemberIdAndChatRoomId(Long memberId, Long roomId);
+
   List<ChatParticipant> findAllByChatRoom_Id(Long chatRoomId);
 
   Optional<ChatParticipant> findByMember_Id(Long memberId);

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatMessageRepositoryImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/impl/CustomChatMessageRepositoryImpl.java
@@ -28,7 +28,7 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
         .fetchJoin()
         .where(
             ltMessageId(messageId), //no-offset 페이징 처리
-            chatMessage.room.id.eq(roomId)
+            chatMessage.chatRoom.id.eq(roomId)
         )
         .limit(pageable.getPageSize() + 1)  //마지막 페이지 확인을 위해서 +1 조회
         .orderBy(chatMessage.sendAt.desc())

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatParticipantService.java
@@ -1,6 +1,7 @@
 package com.halfgallon.withcon.domain.chat.service;
 
 import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
+import com.halfgallon.withcon.domain.chat.dto.ChatLastReadMessage;
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,4 +9,6 @@ import org.springframework.data.domain.Pageable;
 public interface ChatParticipantService {
 
   Page<ChatParticipantResponse> findMyChatRoom(CustomUserDetails customUserDetails, Pageable pageable);
+
+  ChatLastReadMessage.Response readToLastChat(ChatLastReadMessage.Request request);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatParticipantServiceImpl.java
@@ -1,9 +1,14 @@
 package com.halfgallon.withcon.domain.chat.service.impl;
 
+import static com.halfgallon.withcon.global.exception.ErrorCode.PARTICIPANT_NOT_FOUND;
+
 import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
+import com.halfgallon.withcon.domain.chat.dto.ChatLastReadMessage;
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantResponse;
+import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
 import com.halfgallon.withcon.domain.chat.repository.ChatParticipantRepository;
 import com.halfgallon.withcon.domain.chat.service.ChatParticipantService;
+import com.halfgallon.withcon.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +26,15 @@ public class ChatParticipantServiceImpl implements ChatParticipantService {
   public Page<ChatParticipantResponse> findMyChatRoom(CustomUserDetails customUserDetails, Pageable pageable) {
     return chatParticipantRepository.findAllMyChattingRoom(customUserDetails.getId(), pageable)
         .map(ChatParticipantResponse::fromEntity);
+  }
+
+  @Override
+  public ChatLastReadMessage.Response readToLastChat(ChatLastReadMessage.Request request) {
+    ChatParticipant chatParticipant = chatParticipantRepository.findByMemberIdAndChatRoomId(
+        request.getMemberId(), request.getChatRoomId())
+        .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+    return ChatLastReadMessage.Response.fromEntity(chatParticipant);
   }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -217,14 +217,15 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   public Slice<ChatMessageDto> findAllMessageChatRoom(CustomUserDetails customUserDetails,
       ChatLastMessageRequest request, Long chatRoomId) {
 
-    participantRepository.findByMemberIdAndChatRoomId(customUserDetails.getId(), chatRoomId)
+    ChatParticipant chatParticipant = participantRepository.findByMemberIdAndChatRoomId(
+            customUserDetails.getId(), chatRoomId)
         .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
     Slice<ChatMessage> message = chatMessageRepository.findChatRoomMessage(
         request.lastMsgId(), chatRoomId,
         Pageable.ofSize(request.limit() != 0 ? request.limit() : CHAT_MESSAGE_PAGE_SIZE));
 
-    return message.map(ChatMessageDto::fromEntity);
+    return message.map(m -> ChatMessageDto.fromEntity(m, chatParticipant));
   }
 
   @Override

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,6 +1,7 @@
 package com.halfgallon.withcon.domain.chat.service.impl;
 
 import static com.halfgallon.withcon.domain.chat.constant.ChattingConstant.CHAT_MESSAGE_PAGE_SIZE;
+import static com.halfgallon.withcon.domain.chat.constant.EnterStatus.*;
 import static com.halfgallon.withcon.global.exception.ErrorCode.CHATROOM_NOT_FOUND;
 import static com.halfgallon.withcon.global.exception.ErrorCode.DUPLICATE_CHATROOM_NAME;
 import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
@@ -158,6 +159,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Override
   @Transactional
   public ChatRoomEnterResponse enterChatRoom(CustomUserDetails customUserDetails, Long chatRoomId) {
+    boolean isEnter = false; //입장 여부 체크 : 첫 입장: true, 재입장: false
+
     Member member = memberRepository.findById(customUserDetails.getId())
         .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
@@ -165,15 +168,15 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         .orElseThrow(() -> new CustomException(CHATROOM_NOT_FOUND));
 
     //채팅방 참여 인원 저장(첫 방문인 경우 데이터 저장)
-    participantRepository.findByMemberIdAndChatRoomId(customUserDetails.getId(), chatRoomId)
-        .ifPresentOrElse(
-            participant -> {},
-            () -> chatRoom.addChatParticipant(participantRepository.save(
-                ChatParticipant.builder()
-                    .chatRoom(chatRoom)
-                    .member(member)
-                    .build()))
-        );
+    if (!participantRepository.existsByMemberIdAndChatRoomId(customUserDetails.getId(), chatRoomId)) {
+      chatRoom.addChatParticipant(participantRepository.save(
+          ChatParticipant.builder()
+              .chatRoom(chatRoom)
+              .member(member)
+              .build()));
+
+      isEnter = true;
+    }
 
     //채팅방 참여하고 있는 인원 리스트
     List<ChatParticipantDto> chatParticipants = chatRoom.getChatParticipants()
@@ -187,6 +190,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         .userCount(chatRoom.getUserCount())
         .chatParticipants(chatParticipants)
         .performanceName(PerformanceResponse.fromEntity(chatRoom.getPerformance()).getName())
+        .enterStatus(isEnter ? NEW : ALREADY)
         .build();
   }
 

--- a/src/main/java/com/halfgallon/withcon/domain/notification/event/handler/NewMessageEventHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/event/handler/NewMessageEventHandler.java
@@ -10,7 +10,7 @@ import com.halfgallon.withcon.domain.notification.dto.NotificationResponse;
 import com.halfgallon.withcon.domain.notification.entity.Notification;
 import com.halfgallon.withcon.domain.notification.event.NewMessageEvent;
 import com.halfgallon.withcon.domain.notification.repository.NotificationRepository;
-import com.halfgallon.withcon.domain.notification.service.RedisCacheService;
+import com.halfgallon.withcon.domain.notification.service.RedisService;
 import com.halfgallon.withcon.domain.notification.service.RedisNotificationService;
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 public class NewMessageEventHandler {
 
   private final RedisNotificationService redisNotificationService;
-  private final RedisCacheService redisCacheService;
+  private final RedisService redisService;
   private final MemberRepository memberRepository;
   private final NotificationRepository notificationRepository;
 
@@ -37,7 +37,7 @@ public class NewMessageEventHandler {
         + event.getChatRoomId();
     log.info("Event Handle : 채널 KEY: " + visibleKey);
 
-    Map<Object, Object> cache = redisCacheService.getHashByKey(visibleKey);
+    Map<Object, Object> cache = redisService.getHashByKey(visibleKey);
     log.info("Event : Visible 캐시 데이터 조회" + cache);
 
     if(cache != null) { // 기존 캐시 Map이 존재 한다면
@@ -52,7 +52,7 @@ public class NewMessageEventHandler {
               });
         }
       }
-      redisCacheService.saveToHash(visibleKey, cache, 24);
+      redisService.saveToHash(visibleKey, cache, 24);
     }
   }
   private void newMessageSaveAndPublish(NewMessageEvent event, Member member) {

--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/RedisService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/RedisService.java
@@ -1,8 +1,9 @@
 package com.halfgallon.withcon.domain.notification.service;
 
+import com.halfgallon.withcon.domain.chat.dto.ChatRoomSessionDto;
 import java.util.Map;
 
-public interface RedisCacheService {
+public interface RedisService {
 
   // hashKey로 조회
   Map<Object, Object> getHashByKey(String key);

--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/RedisService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/RedisService.java
@@ -14,6 +14,7 @@ public interface RedisService {
   // HashKey - Map 값 변경
   void updateToHash(String hashKey, Object field, Object value);
 
-  void deleteToHash(String hashKey);
+  ChatRoomSessionDto getChatRoomHashKey(String key, String sessionId);
 
+  void deleteHashKey(String hashKey, Object value);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/NotificationServiceImpl.java
@@ -16,7 +16,7 @@ import com.halfgallon.withcon.domain.notification.entity.Notification;
 import com.halfgallon.withcon.domain.notification.repository.NotificationRepository;
 import com.halfgallon.withcon.domain.notification.repository.SseEmitterRepository;
 import com.halfgallon.withcon.domain.notification.service.NotificationService;
-import com.halfgallon.withcon.domain.notification.service.RedisCacheService;
+import com.halfgallon.withcon.domain.notification.service.RedisService;
 import com.halfgallon.withcon.domain.notification.service.RedisNotificationService;
 import com.halfgallon.withcon.domain.notification.service.SseEmitterService;
 import com.halfgallon.withcon.global.exception.CustomException;
@@ -46,7 +46,7 @@ public class NotificationServiceImpl implements NotificationService {
 
   private final SseEmitterService sseEmitterService;
   private final RedisNotificationService redisNotificationService;
-  private final RedisCacheService redisCacheService;
+  private final RedisService redisService;
 
   @Override
   public SseEmitter subscribe(Long memberId) {
@@ -108,7 +108,7 @@ public class NotificationServiceImpl implements NotificationService {
         + request.getChatRoomId();
     log.info("Service : 채널 KEY: " + visibleKey);
 
-    Map<Object, Object> cache = redisCacheService.getHashByKey(visibleKey);
+    Map<Object, Object> cache = redisService.getHashByKey(visibleKey);
     log.info("Service : Visible 캐시 데이터 조회" + cache);
 
     for (ChatParticipant chatParticipant : chatParticipants) {

--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/RedisNotificationServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/RedisNotificationServiceImpl.java
@@ -3,7 +3,7 @@ package com.halfgallon.withcon.domain.notification.service.impl;
 import com.halfgallon.withcon.domain.notification.constant.RedisCacheType;
 import com.halfgallon.withcon.domain.notification.dto.NotificationResponse;
 import com.halfgallon.withcon.domain.notification.dto.VisibleRequest;
-import com.halfgallon.withcon.domain.notification.service.RedisCacheService;
+import com.halfgallon.withcon.domain.notification.service.RedisService;
 import com.halfgallon.withcon.domain.notification.service.RedisNotificationService;
 import com.halfgallon.withcon.domain.notification.service.handler.RedisListener;
 import java.util.HashMap;
@@ -23,7 +23,7 @@ public class RedisNotificationServiceImpl implements RedisNotificationService {
   private final RedisMessageListenerContainer container;
   private final RedisListener subscriber;
   private final RedisTemplate<String, Object> redisTemplate;
-  private final RedisCacheService redisCacheService;
+  private final RedisService redisService;
 
   @Override
   public void subscribe(String channel) {
@@ -50,17 +50,17 @@ public class RedisNotificationServiceImpl implements RedisNotificationService {
     String hashKey = RedisCacheType.VISIBLE_CACHE.getDescription() + request.getChatRoomId();
     log.info("VisibleCache 채널 명 : " + hashKey);
 
-    Map<Object, Object> visibleCaches = redisCacheService.getHashByKey(hashKey);
+    Map<Object, Object> visibleCaches = redisService.getHashByKey(hashKey);
     log.info("Service : 특정 채팅방에 대한 Visible Map 조회 성공" + visibleCaches);
 
     if (visibleCaches != null) { // 특정 채팅방의 Map이 이미 존재한다면
-      redisCacheService.updateToHash(hashKey, String.valueOf(memberId), request.getVisibleType());
+      redisService.updateToHash(hashKey, String.valueOf(memberId), request.getVisibleType());
       log.info("Redis Visible 기존 Map 변경 " + memberId +
           " : " + request.getVisibleType());
     } else {
       Map<Object, Object> newObject = new HashMap<>();
       newObject.put(String.valueOf(memberId), request.getVisibleType());
-      redisCacheService.saveToHash(hashKey, newObject, 24);
+      redisService.saveToHash(hashKey, newObject, 24);
       log.info("Redis Visible 새로운 Map 추가 " + memberId +
           " : " + request.getVisibleType());
     }

--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/RedisServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/RedisServiceImpl.java
@@ -36,7 +36,13 @@ public class RedisServiceImpl implements RedisService {
   }
 
   @Override
-  public void deleteToHash(String hashKey) {
-    redisTemplate.delete(hashKey);
+  public ChatRoomSessionDto getChatRoomHashKey(String key, String sessionId) {
+    HashOperations<String, Object, ChatRoomSessionDto> hashOps = redisTemplate.opsForHash();
+    return hashOps.get(key, sessionId);
+  }
+
+  @Override
+  public void deleteHashKey(String hashKey, Object value) {
+    redisTemplate.opsForHash().delete(hashKey, value);
   }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/RedisServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/notification/service/impl/RedisServiceImpl.java
@@ -1,6 +1,7 @@
 package com.halfgallon.withcon.domain.notification.service.impl;
 
-import com.halfgallon.withcon.domain.notification.service.RedisCacheService;
+import com.halfgallon.withcon.domain.chat.dto.ChatRoomSessionDto;
+import com.halfgallon.withcon.domain.notification.service.RedisService;
 import java.time.Duration;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RedisCacheServiceImpl implements RedisCacheService {
+public class RedisServiceImpl implements RedisService {
 
   private final RedisTemplate<String, Object> redisTemplate;
 

--- a/src/test/http/chatRoom.http
+++ b/src/test/http/chatRoom.http
@@ -66,3 +66,12 @@ Authorization: {{accessToken}}
 %}
 GET http://localhost:8080/chatRoom/performance/{{performanceId}}/tag/{{tag}}
 Content-Type: application/json
+
+### 마지막 메시지 확인
+POST http://localhost:8080/chatRoom/lastChat
+Content-Type: application/json
+
+{
+  "memberId": 2,
+  "chatRoomId": 1
+}


### PR DESCRIPTION
## 📝작업 내용

1. 채팅 입장 상태 확인
   1. 채팅방 입장 상태 enum 클래스 생성
      - EnterStatus : `NEW`(첫 입장), `ALREADY`(재입장)
   2. 채팅방 입장 response 데이터 추가
      - 채팅방 입장 response -> `EnterStatus` 데이터 추가
   3. 채팅방 재입장 여부 `existsBy` 메서드 생성
      - 해당 메서드를 활용하여 입장 상태 여부 체크

2. 채팅방 입장, 구독, 퇴장 여부 확인
   1. `StompPreHandler` 생성
       - 해당 Handler를 이용하여 StompCommand Status에 맞는 조건 생성
   2. Stomp PreSend(...)
       - Stomp `연결` 시에 `Authorization` 토큰을 활용하여 유저 정보 저장
       - Stomp `구독` 시에 `sessionId`와 연결 시에 저장했던 유저 정보를 활용하여 데이터를 `redis`에 저장
       - Stomp `삭제` 시에 `redis`에서 데이터를 불러와서 해당 데이터 검증 후에 삭제한다.

3. 채팅 참여자 마지막 메시지 ID 저장
   1. `ChatParticipant` DB에 `lastReadId` 컬럼 생성
       - StompCommand `Disconnect` 시에 채팅방 퇴장이 아닌 `뒤로 가기`에 해당하는 경우 현재 ChatMessage DB 상에 최근에 작성된 메시지 ID를 저장하기 위한 데이터 생성
   2. 채팅방 참여한 사람의 마지막 메시지 API 생성
       - 채팅에 참여한 사람의 마지막 메시지 ID 데이터를 확인할 수 있는 프로토콜 생성

## 💬리뷰 참고사항

- 마지막 메시지 ID 체크 확인
   - Stomp Disconnect(채팅방 퇴장 or 뒤로 가기) 진행 시에 해당 채팅방 참여자 여부를 판단하여
     채팅 참여자가 마지막으로 읽은 메시지 ID를 저장

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/1ba7aea2-ff19-4704-8cdb-3b478d1f01a0)



- [x] API 테스트 (채팅 Enter response)

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/d5eb29b9-94fc-492e-9780-eb4c7545bafc)

- [x] API 테스트 (STOMP 연결 - `Authorization`  토큰 연결 )

![image](https://github.com/HalfGallonTeam/WithCon_BE/assets/124044861/173a484c-348d-46b3-b415-08b3a0fb2f50)


## #️⃣연관된 이슈

close #126 #127 #128 
