### PR TITLE
[bug] 채팅방 퇴장 및 강퇴 기능 버그 수정

### DIFF
--- a/src/main/java/com/halfgallon/withcon/domain/chat/config/Handler/StompPreHandler.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/config/Handler/StompPreHandler.java
@@ -51,15 +51,12 @@ public class StompPreHandler implements ChannelInterceptor {
         MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
     assert accessor != null;
-    log.info("accessor.getCommand() : {}", accessor.getCommand());
 
     if (StompCommand.CONNECT.equals(accessor.getCommand())) {
       String token = resolveToken(accessor.getFirstNativeHeader("Authorization"));
-
-      log.info("[preSend] stomp connection : {}", token);
+      log.info("[preSend] stomp connection token : {}", token);
 
       AccessToken findAccessToken = findAccessTokenOrThrow(token);
-
       Member member = findMemberOrThrow(findAccessToken.getMemberId());
 
       // WS Header save to userData
@@ -76,14 +73,11 @@ public class StompPreHandler implements ChannelInterceptor {
           accessor.getSessionId());
 
       String sessionId = accessor.getSessionId();
-      log.info("[preSend] stomp subscribe sessionId : {}", sessionId);
 
       Member member = memberRepository.findByUsername(accessor.getUser().getName())
           .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
       Long roomId = getRoomIdFromDestination(Objects.requireNonNull(accessor.getDestination()));
-      log.info("[preSend] stomp subscribe roomId : {}", roomId);
-
       ChatRoom chatRoom = findChatRoomOrThrow(roomId);
 
       saveSession(chatRoom.getId(), member.getId(), sessionId);

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageDto.java
@@ -2,7 +2,6 @@ package com.halfgallon.withcon.domain.chat.dto;
 
 import com.halfgallon.withcon.domain.chat.constant.MessageType;
 import com.halfgallon.withcon.domain.chat.entity.ChatMessage;
-import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,15 +32,4 @@ public class ChatMessageDto {
         .build();
   }
 
-  public static ChatMessageDto fromEntity(ChatMessage chatMessage, ChatParticipant chatParticipant) {
-    return ChatMessageDto.builder()
-        .roomId(chatMessage.getChatRoom().getId())
-        .memberId(chatMessage.getChatParticipant().getId())
-        .message(chatMessage.getMessage())
-        .messageType(chatMessage.getMessageType())
-        .sendAt(chatMessage.getSendAt())
-        .nickName(chatParticipant.getMember().getNickname())
-        .userProfile(chatParticipant.getMember().getProfileImage())
-        .build();
-  }
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,31 @@
+package com.halfgallon.withcon.domain.chat.dto;
+
+import com.halfgallon.withcon.domain.chat.constant.MessageType;
+import com.halfgallon.withcon.domain.chat.entity.ChatMessage;
+import com.halfgallon.withcon.domain.chat.entity.ChatParticipant;
+import lombok.Builder;
+
+@Builder
+public record ChatMessageResponse (
+    Long memberId,
+    Long roomId,
+    Long messageId,
+    String message,
+    MessageType messageType,
+    String nickName,
+    String userProfile,
+    Long sendAt
+) {
+  public static ChatMessageResponse fromEntity(ChatMessage chatMessage, ChatParticipant chatParticipant) {
+    return ChatMessageResponse.builder()
+        .roomId(chatMessage.getChatRoom().getId())
+        .messageId(chatMessage.getId())
+        .message(chatMessage.getMessage())
+        .messageType(chatMessage.getMessageType())
+        .sendAt(chatMessage.getSendAt())
+        .memberId(chatParticipant.getMember().getId())
+        .nickName(chatParticipant.getMember().getNickname())
+        .userProfile(chatParticipant.getMember().getProfileImage())
+        .build();
+  }
+}

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.halfgallon.withcon.domain.chat.repository;
 
 import com.halfgallon.withcon.domain.chat.entity.ChatMessage;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,5 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     CustomChatMessageRepository{
   Optional<ChatMessage> findTopByChatRoomIdOrderBySendAtDesc(Long chatRoomId);
 
+  List<ChatMessage> findAllByChatParticipantId(Long ChatParticipantId);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/repository/ChatMessageRepository.java
@@ -11,5 +11,5 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     CustomChatMessageRepository{
   Optional<ChatMessage> findTopByChatRoomIdOrderBySendAtDesc(Long chatRoomId);
 
-  List<ChatMessage> findAllByChatParticipantId(Long ChatParticipantId);
+  List<ChatMessage> findAllByChatRoomIdAndChatParticipantId(Long chatRoomId, Long ChatParticipantId);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/ChatRoomService.java
@@ -1,8 +1,8 @@
 package com.halfgallon.withcon.domain.chat.service;
 
 import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
-import com.halfgallon.withcon.domain.chat.dto.ChatMessageDto;
 import com.halfgallon.withcon.domain.chat.dto.ChatLastMessageRequest;
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomEnterResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomRequest;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomResponse;
@@ -22,8 +22,8 @@ public interface ChatRoomService {
 
   ChatRoomResponse kickChatRoom(CustomUserDetails customUserDetails, Long chatRoomId, Long memberId);
 
-  Slice<ChatMessageDto> findAllMessageChatRoom(CustomUserDetails customUserDetails, ChatLastMessageRequest request,
-      Long chatRoomId);
+  Slice<ChatMessageResponse> findAllMessageChatRoom(CustomUserDetails customUserDetails,
+      ChatLastMessageRequest request, Long chatRoomId);
 
   Page<ChatRoomResponse> findAllTagNameChatRoom(String performanceId, String tagName, Pageable pageable);
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,7 +1,8 @@
 package com.halfgallon.withcon.domain.chat.service.impl;
 
 import static com.halfgallon.withcon.domain.chat.constant.ChattingConstant.CHAT_MESSAGE_PAGE_SIZE;
-import static com.halfgallon.withcon.domain.chat.constant.EnterStatus.*;
+import static com.halfgallon.withcon.domain.chat.constant.EnterStatus.ALREADY;
+import static com.halfgallon.withcon.domain.chat.constant.EnterStatus.NEW;
 import static com.halfgallon.withcon.global.exception.ErrorCode.CHATROOM_NOT_FOUND;
 import static com.halfgallon.withcon.global.exception.ErrorCode.DUPLICATE_CHATROOM_NAME;
 import static com.halfgallon.withcon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
@@ -9,8 +10,8 @@ import static com.halfgallon.withcon.global.exception.ErrorCode.PARTICIPANT_NOT_
 import static com.halfgallon.withcon.global.exception.ErrorCode.PERFORMANCE_NOT_FOUND;
 
 import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
-import com.halfgallon.withcon.domain.chat.dto.ChatMessageDto;
 import com.halfgallon.withcon.domain.chat.dto.ChatLastMessageRequest;
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageDto;
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantDto;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomEnterResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomRequest;
@@ -197,12 +198,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Override
   @Transactional
   public void exitChatRoom(CustomUserDetails customUserDetails, Long chatRoomId) {
-    ChatParticipant participant
-        = participantRepository.findByMemberIdAndChatRoomId(customUserDetails.getId(), chatRoomId)
-        .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+    ChatParticipant participant = findChatParticipantOrThrow(chatRoomId, customUserDetails.getId());
 
-    participantRepository.delete(participant);
-    participant.getChatRoom().removeChatParticipant(participant);
+    deleteChattingData(participant);
 
     ChatRoomResponse response = ChatRoomResponse.fromEntity(participant.getChatRoom());
 
@@ -217,9 +215,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   public Slice<ChatMessageDto> findAllMessageChatRoom(CustomUserDetails customUserDetails,
       ChatLastMessageRequest request, Long chatRoomId) {
 
-    ChatParticipant chatParticipant = participantRepository.findByMemberIdAndChatRoomId(
-            customUserDetails.getId(), chatRoomId)
-        .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+    ChatParticipant chatParticipant = findChatParticipantOrThrow(chatRoomId, customUserDetails.getId());
 
     Slice<ChatMessage> message = chatMessageRepository.findChatRoomMessage(
         request.lastMsgId(), chatRoomId,
@@ -240,16 +236,28 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   public ChatRoomResponse kickChatRoom(CustomUserDetails customUserDetails, Long chatRoomId,
       Long memberId) {
     //현재 채팅방에서 강퇴할 인원 참여 여부 체크
-    ChatParticipant chatParticipant = participantRepository.findByMemberIdAndChatRoomId(
-            memberId, chatRoomId)
-        .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+    ChatParticipant chatParticipant = findChatParticipantOrThrow(chatRoomId, memberId);
 
     if (participantRepository.checkRoomManagerId(customUserDetails.getId())) {
-      participantRepository.delete(chatParticipant);
-      chatParticipant.getChatRoom().removeChatParticipant(chatParticipant);
+      deleteChattingData(chatParticipant);
     }
 
     return ChatRoomResponse.fromEntity(chatParticipant.getChatRoom());
+  }
+
+  private ChatParticipant findChatParticipantOrThrow(Long chatRoomId, Long memberId) {
+    return participantRepository.findByMemberIdAndChatRoomId(memberId, chatRoomId)
+        .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+  }
+
+  private void deleteChattingData(ChatParticipant chatParticipant) {
+    List<ChatMessage> messages = chatMessageRepository.findAllByChatParticipantId(chatParticipant.getId());
+    if (!CollectionUtils.isEmpty(messages)) {
+      chatMessageRepository.deleteAll(messages);
+    }
+
+    participantRepository.delete(chatParticipant);
+    chatParticipant.getChatRoom().removeChatParticipant(chatParticipant);
   }
 
 }

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -11,7 +11,7 @@ import static com.halfgallon.withcon.global.exception.ErrorCode.PERFORMANCE_NOT_
 
 import com.halfgallon.withcon.domain.auth.security.service.CustomUserDetails;
 import com.halfgallon.withcon.domain.chat.dto.ChatLastMessageRequest;
-import com.halfgallon.withcon.domain.chat.dto.ChatMessageDto;
+import com.halfgallon.withcon.domain.chat.dto.ChatMessageResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatParticipantDto;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomEnterResponse;
 import com.halfgallon.withcon.domain.chat.dto.ChatRoomRequest;
@@ -212,7 +212,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
   @Override
   @Transactional(readOnly = true)
-  public Slice<ChatMessageDto> findAllMessageChatRoom(CustomUserDetails customUserDetails,
+  public Slice<ChatMessageResponse> findAllMessageChatRoom(CustomUserDetails customUserDetails,
       ChatLastMessageRequest request, Long chatRoomId) {
 
     ChatParticipant chatParticipant = findChatParticipantOrThrow(chatRoomId, customUserDetails.getId());
@@ -221,7 +221,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         request.lastMsgId(), chatRoomId,
         Pageable.ofSize(request.limit() != 0 ? request.limit() : CHAT_MESSAGE_PAGE_SIZE));
 
-    return message.map(m -> ChatMessageDto.fromEntity(m, chatParticipant));
+    return message.map(m -> ChatMessageResponse.fromEntity(m, chatParticipant));
   }
 
   @Override

--- a/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/halfgallon/withcon/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -200,7 +200,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   public void exitChatRoom(CustomUserDetails customUserDetails, Long chatRoomId) {
     ChatParticipant participant = findChatParticipantOrThrow(chatRoomId, customUserDetails.getId());
 
-    deleteChattingData(participant);
+    deleteChattingData(chatRoomId, participant);
 
     ChatRoomResponse response = ChatRoomResponse.fromEntity(participant.getChatRoom());
 
@@ -239,7 +239,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     ChatParticipant chatParticipant = findChatParticipantOrThrow(chatRoomId, memberId);
 
     if (participantRepository.checkRoomManagerId(customUserDetails.getId())) {
-      deleteChattingData(chatParticipant);
+      deleteChattingData(chatRoomId, chatParticipant);
     }
 
     return ChatRoomResponse.fromEntity(chatParticipant.getChatRoom());
@@ -250,8 +250,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
   }
 
-  private void deleteChattingData(ChatParticipant chatParticipant) {
-    List<ChatMessage> messages = chatMessageRepository.findAllByChatParticipantId(chatParticipant.getId());
+  private void deleteChattingData(Long chatRoomId, ChatParticipant chatParticipant) {
+    List<ChatMessage> messages = chatMessageRepository.findAllByChatRoomIdAndChatParticipantId(
+        chatRoomId, chatParticipant.getId());
+
     if (!CollectionUtils.isEmpty(messages)) {
       chatMessageRepository.deleteAll(messages);
     }


### PR DESCRIPTION
## 📝작업 내용

1. 채팅 메시지를 발송 후에 퇴장 및 강퇴를 진행 시에 exception 발생

    - 채팅방 퇴장 및 강퇴 진행 시에 `chatMessage` 엔티티의 컬럼 중 하나인 `chatParticipant` 엔티티가 삭제되면서 
    외래키(`FK`) 설정 에러 발생 
    - 채팅방 퇴장 및 강퇴 시에 해당 `참여자 ID`를 기준으로 메시지 내역을 조회하여 
    해당 삭제 후에 이전 시퀀스 대로 진행

2. 불필요한 log 내역 삭제

## 💬리뷰 참고사항

- [x] API 테스트 진행

## #️⃣연관된 이슈
_No_Response_
